### PR TITLE
Tag nightly ingest rows with NIGHTLY=1 env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The pipeline is [**`vllm/perf-eval`**](https://buildkite.com/vllm/perf-eval). Wi
 **Optional env vars:**
 
 - `WORKLOADS` — comma- or newline-separated list of workload paths or stems. Runs exactly those instead of the default `nightly: true` set.
+- `NIGHTLY` — set to `1` to tag every ingested row with `nightly: true`. The dashboard's `/nightly` view filters on this to pair adjacent nightly builds; only the scheduled nightly cron should set it.
 
 **Example — trigger a build from the Buildkite UI:**
 

--- a/lib/ingest.py
+++ b/lib/ingest.py
@@ -42,6 +42,9 @@ VLLM_ENV_VARS = (
     ("WORKLOAD_IMAGE", "image"),
     ("WORKLOAD_VLLM_COMMIT", "vllm_commit"),
 )
+# Set NIGHTLY=1 in the build env to mark rows as part of the nightly schedule.
+# The dashboard's /nightly view filters on this to pair adjacent nightlies.
+NIGHTLY_ENV = "NIGHTLY"
 
 
 def post(endpoint: str, payload: dict) -> None:
@@ -67,6 +70,8 @@ def metadata(workload: str, task: str) -> dict:
         v = (os.environ.get(env_key) or "").strip()
         if v:
             md[field] = v
+    if os.environ.get(NIGHTLY_ENV) == "1":
+        md["nightly"] = True
     return md
 
 

--- a/lib/ingest_perf.py
+++ b/lib/ingest_perf.py
@@ -69,6 +69,9 @@ def transform(raw: dict, args: argparse.Namespace) -> dict:
         "input_tput_per_gpu": input_throughput / tp,
     }
 
+    if os.environ.get("NIGHTLY") == "1":
+        data["nightly"] = True
+
     # Convert *_ms fields to seconds and emit interactivity (1000/tpot_ms).
     for key, value in raw.items():
         if not key.endswith("_ms"):


### PR DESCRIPTION
## Summary
- When the build env has `NIGHTLY=1`, both `lib/ingest.py` and `lib/ingest_perf.py` include `nightly: true` in the ingested payload
- The dashboard's new `/nightly` page filters on this field to discover and pair adjacent nightly builds by commit SHA
- Documents the new env var in README alongside `WORKLOADS`

## Companion PR
The dashboard side is in vllm-project/vllm-dashboard (branch `nightly-page`).

## Test plan
- [x] Smoke-tested both ingest scripts locally: `NIGHTLY=1` adds `nightly: true`, unset/`0` omits it
- [x] Shell syntax check passes (`bash -n lib/run.sh && bash -n lib/server.sh && bash -n lib/run_lm_eval.sh`)
- [ ] Set `NIGHTLY=1` on the next scheduled nightly build and verify rows appear with `message:nightly::BOOLEAN = TRUE` in Databricks

This PR was authored with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)