### PR TITLE
Add BFCL function-calling evaluation support

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -164,7 +164,13 @@ def make_step(path, data, profiles):
     bench_only = is_truthy(os.environ.get("BENCH_ONLY")) or is_truthy(
         data.get("bench_only")
     )
-    setup_commands = BENCH_ONLY_SETUP_COMMANDS if bench_only else FULL_SETUP_COMMANDS
+    has_bfcl = bool(data.get("bfcl"))
+    if bench_only:
+        setup_commands = BENCH_ONLY_SETUP_COMMANDS
+    elif has_bfcl:
+        setup_commands = [setup_command("'lm-eval[api]' pyyaml bfcl-eval soundfile")]
+    else:
+        setup_commands = FULL_SETUP_COMMANDS
     step = {
         "label": f"{emoji} {name}",
         "agents": {"queue": queue},

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ CLAUDE.md         agent conventions and detailed Buildkite workflow
 
 ### Recipe schema
 
-A recipe has top-level metadata plus three blocks:
+A recipe has top-level metadata plus up to three eval blocks:
 
 - **`vllm:`** — *how the server runs.* Defines what model to serve and how (`model`, `serve_args`, optional image/env overrides). Required.
 - **`lm_eval:`** — *what accuracy to measure.* Lists lm-evaluation-harness tasks to run against the live server (e.g. `gsm8k`, `aime25`). Each task's score is saved under `results/<name>/<task-name>/`. Optional.
 - **`vllm_bench:`** — *what perf to measure.* Lists `vllm bench serve` configs (input/output lengths, concurrency, dataset). Raw JSON is saved and ingested into the perf dashboard. Optional.
+- **`bfcl:`** — *function-calling eval.* Runs [BFCL](https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard) test categories against the live server. Some models need `--enable-auto-tool-choice` and `--tool-call-parser` in `serve_args`. Results are transformed to lm_eval format and ingested as `bfcl_<category>` tasks. Optional.
 
-Include either or both of `lm_eval:` / `vllm_bench:` depending on what you want out of this recipe.
+Include one or more of `lm_eval:` / `vllm_bench:` / `bfcl:` depending on what you want out of this recipe.
 
 ```yaml
 name: qwen3_5-h200       # used in container name and results/<name>/
@@ -60,6 +61,14 @@ lm_eval:                 # accuracy tasks (optional)
     - name: aime25
       num_fewshot: 0
 
+bfcl:                    # function-calling eval (optional)
+  test_categories:       # BFCL test categories to run
+    - simple_python
+    - multiple
+    - parallel
+  num_threads: 8         # optional, default 8
+  temperature: 0.001     # optional, default 0.001
+
 vllm_bench:              # perf runs (optional) — fed to the perf dashboard
   configs:
     - name: 1k-in-1k-out-conc-256
@@ -76,6 +85,7 @@ A few things worth knowing:
 - **`nightly`** controls only the nightly schedule. Recipes with `nightly: false` (or omitted) are still triggerable explicitly via the `WORKLOADS` env var.
 - **`lm_eval.tasks` is a list** because each entry runs as a separate `lm_eval` invocation — `--num_fewshot` is a single global flag, so different shot counts need separate runs. Each task's results land in `results/<name>/<task-name>/`.
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
+- **`bfcl` may need tool-call serve args.** Some models require `--enable-auto-tool-choice` and `--tool-call-parser` for function-calling; the parser warns if `--tool-call-parser` is absent. Each category runs as a separate generate + evaluate pass; scores appear on the eval dashboard as `bfcl_<category>` tasks.
 
 For everything else (the full set of supported fields, defaults, validation rules), the existing files in `workloads/` are the working reference and `lib/parse_workload.py` is the source of truth.
 

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -26,6 +26,18 @@ BENCH_FIELDS = {
     "speed_bench_dataset_subset", "speed_bench_category",
 }
 BENCH_REQUIRED = ("name", "input_len", "output_len", "num_prompts", "max_concurrency")
+BFCL_FIELDS = {"test_categories", "num_threads", "temperature"}
+BFCL_KNOWN_CATEGORIES = {
+    "simple_python", "simple_java", "simple_javascript",
+    "multiple", "parallel", "parallel_multiple", "irrelevance",
+    "live_simple", "live_multiple", "live_parallel",
+    "live_parallel_multiple", "live_irrelevance", "live_relevance",
+    "multi_turn_base", "multi_turn_miss_func",
+    "multi_turn_miss_param", "multi_turn_long_context",
+    "memory_kv", "memory_vector", "memory_rec_sum",
+    "all", "all_scoring", "single_turn", "multi_turn",
+    "live", "non_live", "non_python", "python", "memory", "agentic",
+}
 COMMIT_IMAGE_TEMPLATE = "vllm/vllm-openai:nightly-{commit}"
 
 
@@ -181,6 +193,28 @@ def bench_tsv(configs: list, path: str) -> str:
     return "\n".join(lines)
 
 
+def validate_bfcl(bfcl: dict, serve_args: str, path: str) -> None:
+    extra = set(bfcl) - BFCL_FIELDS
+    if extra:
+        sys.exit(f"{path}: bfcl block has unsupported fields {sorted(extra)}")
+    cats = bfcl.get("test_categories") or []
+    if not cats:
+        sys.exit(f"{path}: bfcl block requires at least one test_categories entry")
+    for cat in cats:
+        if cat not in BFCL_KNOWN_CATEGORIES:
+            sys.exit(f"{path}: unknown bfcl test category {cat!r}")
+    if "--tool-call-parser" not in serve_args:
+        print(f"WARNING: {path}: bfcl without --tool-call-parser in serve_args; "
+              "some models may need it for function-calling", file=sys.stderr)
+
+
+def bfcl_tsv(bfcl: dict) -> str:
+    cats = bfcl.get("test_categories") or []
+    num_threads = bfcl.get("num_threads", 8)
+    temperature = bfcl.get("temperature", 0.001)
+    return "\n".join(f"{cat}\t{num_threads}\t{temperature}" for cat in cats)
+
+
 def main(path: str) -> None:
     with open(path) as f:
         data = yaml.safe_load(f)
@@ -194,7 +228,18 @@ def main(path: str) -> None:
     bench = data.get("vllm_bench") or {}
 
     tasks = lm_eval.get("tasks") or []
-    validate_tasks(tasks, path)
+    bfcl = data.get("bfcl") or {}
+    bench_configs = bench.get("configs") or []
+
+    if not tasks and not bench_configs and not bfcl:
+        sys.exit(f"{path}: workload must define at least one of lm_eval, vllm_bench, or bfcl")
+
+    if tasks:
+        validate_tasks(tasks, path)
+
+    serve_args = vllm.get("serve_args") or ""
+    if bfcl:
+        validate_bfcl(bfcl, serve_args, path)
 
     image, vllm_commit = resolve_image(vllm)
     env = {**(profile.get("env") or {}), **(vllm.get("env") or {})}
@@ -204,17 +249,18 @@ def main(path: str) -> None:
     metadata = bench.get("metadata") or {}
     tp = metadata.get("tp")
     if tp is None:
-        tp = parse_tp(vllm.get("serve_args") or "")
+        tp = parse_tp(serve_args)
 
     emit("NAME", data.get("name", ""))
     emit("IMAGE", image)
     emit("VLLM_COMMIT", vllm_commit)
     emit("MODEL", vllm.get("model", ""))
-    emit("SERVE_ARGS", vllm.get("serve_args", ""))
+    emit("SERVE_ARGS", serve_args)
     emit("SERVER_RUNTIME", profile.get("server_runtime", "docker"))
     emit("ENV", "\n".join(f"{k}={fmt(v)}" for k, v in env.items()))
     emit("LM_EVAL_TASKS_TSV", task_tsv(tasks, lm_eval.get("model_args") or {}))
-    emit("VLLM_BENCH_TSV", bench_tsv(bench.get("configs") or [], path))
+    emit("VLLM_BENCH_TSV", bench_tsv(bench_configs, path))
+    emit("BFCL_TSV", bfcl_tsv(bfcl) if bfcl else "")
     emit("BENCH_DEVICE", metadata.get("device") or gpu.lower())
     emit("BENCH_TP", tp)
     emit("BENCH_PRECISION", metadata.get("precision") or precision_from_model(vllm.get("model") or ""))

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -58,7 +58,7 @@ while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc speed_subset
 done <<< "$WORKLOAD_VLLM_BENCH_TSV"
 
 if [[ "${BENCH_ONLY:-}" =~ ^([Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss])$ ]]; then
-  echo "--- :stopwatch: BENCH_ONLY set; skipping lm_eval tasks"
+  echo "--- :stopwatch: BENCH_ONLY set; skipping lm_eval and bfcl tasks"
   exit 0
 fi
 
@@ -73,3 +73,16 @@ while IFS=$'\t' read -r task fewshot model_args; do
     --task "$task" \
     ${INGEST_NO_SAMPLES:+--no-samples} || true
 done <<< "$WORKLOAD_LM_EVAL_TASKS_TSV"
+
+# bfcl function-calling eval
+while IFS=$'\t' read -r category num_threads temperature; do
+  [[ -z "$category" ]] && continue
+  python3 "$DIR/run_bfcl.py" "$WORKLOAD_MODEL" "$BASE_URL" \
+    "$category" "$num_threads" "$temperature" "$RESULTS_DIR"
+
+  python3 "$DIR/ingest.py" \
+    --results-dir "${RESULTS_DIR}/bfcl-${category}" \
+    --workload "$WORKLOAD_NAME" \
+    --task "bfcl_${category}" \
+    --no-samples || true
+done <<< "$WORKLOAD_BFCL_TSV"

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -77,6 +77,7 @@ done <<< "$WORKLOAD_LM_EVAL_TASKS_TSV"
 # bfcl function-calling eval
 while IFS=$'\t' read -r category num_threads temperature; do
   [[ -z "$category" ]] && continue
+  echo "--- :phone: bfcl ${category}"
   python3 "$DIR/run_bfcl.py" "$WORKLOAD_MODEL" "$BASE_URL" \
     "$category" "$num_threads" "$temperature" "$RESULTS_DIR"
 

--- a/lib/run_bfcl.py
+++ b/lib/run_bfcl.py
@@ -1,0 +1,212 @@
+"""Run a single BFCL test category against a running vLLM server.
+
+Usage:
+    python3 lib/run_bfcl.py <model> <base_url> <category> \
+        <num_threads> <temperature> <results_dir>
+
+Registers the model in BFCL's config, runs generate + evaluate, then
+writes an lm_eval-compatible results JSON so the existing ingest.py
+and dashboard auto-discover the scores without any adapter.
+"""
+
+import csv
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def get_typer_defaults(func):
+    """Extract default kwargs from a Typer-decorated function."""
+    import typer
+
+    defaults = {}
+    for name, default in zip(
+        func.__annotations__.keys(),
+        func.__defaults__,
+        strict=True,
+    ):
+        if isinstance(default, typer.models.OptionInfo):
+            defaults[name] = default.default
+    return defaults
+
+
+def register_model(model: str, base_url: str):
+    """Inject the model into BFCL's MODEL_CONFIG_MAPPING."""
+    import bfcl_eval.constants.model_config as bfcl_model_config
+    from bfcl_eval.model_handler.api_inference.openai_completion import (
+        OpenAICompletionsHandler,
+    )
+
+    bfcl_model_config.MODEL_CONFIG_MAPPING = {
+        model: bfcl_model_config.ModelConfig(
+            model_name=model,
+            display_name=f"{model} (FC) (vLLM)",
+            url=f"https://huggingface.co/{model}",
+            org="",
+            license="apache-2.0",
+            model_handler=OpenAICompletionsHandler,
+            input_price=None,
+            output_price=None,
+            is_fc_model=True,
+            underscore_to_dot=True,
+        )
+    }
+
+
+def run_generate(model, category, num_threads, temperature):
+    from bfcl_eval.__main__ import generate
+
+    kwargs = get_typer_defaults(generate)
+    kwargs["model"] = [model]
+    kwargs["test_category"] = category
+    kwargs["skip_server_setup"] = True
+    kwargs["num_threads"] = num_threads
+    kwargs["temperature"] = temperature
+    generate(**kwargs)
+
+
+def run_evaluate(model, category):
+    from bfcl_eval.__main__ import evaluate
+
+    kwargs = get_typer_defaults(evaluate)
+    kwargs["model"] = [model]
+    kwargs["test_category"] = category
+    evaluate(**kwargs)
+
+
+CATEGORY_TO_CSV = {
+    "simple_python": "data_non_live.csv",
+    "simple_java": "data_non_live.csv",
+    "simple_javascript": "data_non_live.csv",
+    "multiple": "data_non_live.csv",
+    "parallel": "data_non_live.csv",
+    "parallel_multiple": "data_non_live.csv",
+    "irrelevance": "data_non_live.csv",
+    "live_simple": "data_live.csv",
+    "live_multiple": "data_live.csv",
+    "live_parallel": "data_live.csv",
+    "live_parallel_multiple": "data_live.csv",
+    "live_irrelevance": "data_live.csv",
+    "live_relevance": "data_live.csv",
+    "multi_turn_base": "data_multi_turn.csv",
+    "multi_turn_miss_func": "data_multi_turn.csv",
+    "multi_turn_miss_param": "data_multi_turn.csv",
+    "multi_turn_long_context": "data_multi_turn.csv",
+}
+
+
+def parse_score_from_csv(work_dir: Path, model: str, category: str) -> dict | None:
+    """Extract per-category accuracy from BFCL V4 aggregate CSV files."""
+    csv_name = CATEGORY_TO_CSV.get(category)
+    csv_candidates = [work_dir / "score" / csv_name] if csv_name else []
+    csv_candidates.append(work_dir / "score" / "data_overall.csv")
+
+    bfcl_category = f"BFCL_v4_{category}"
+    for csv_path in csv_candidates:
+        if not csv_path.exists():
+            continue
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                model_name = row.get("Model", row.get("model", ""))
+                if model not in model_name and model.replace("/", "_") not in model_name:
+                    continue
+                for key, value in row.items():
+                    if bfcl_category in key:
+                        try:
+                            return {"accuracy": float(value) / 100.0}
+                        except (ValueError, TypeError):
+                            continue
+
+    # Fallback: look for per-category JSONL score files (older BFCL versions)
+    model_slug = model.replace("/", "_")
+    for p in (work_dir / "score").rglob(f"{category}_score.json"):
+        with open(p) as f:
+            return json.loads(f.readline())
+
+    return None
+
+
+def to_lm_eval_format(model: str, category: str, score: dict) -> dict:
+    """Transform BFCL aggregate score into lm_eval-compatible results JSON."""
+    task_name = f"bfcl_{category}"
+    accuracy = score.get("accuracy", 0.0)
+
+    return {
+        "results": {
+            task_name: {
+                "acc,none": accuracy,
+                "acc_stderr,none": 0.0,
+                "alias": task_name,
+            }
+        },
+        "configs": {
+            task_name: {"task": task_name, "num_fewshot": 0}
+        },
+        "versions": {task_name: 1},
+        "n-shot": {task_name: 0},
+        "config": {
+            "model": "local-completions",
+            "model_args": f"model={model}",
+        },
+    }
+
+
+def main():
+    if len(sys.argv) != 7:
+        sys.exit(
+            "usage: run_bfcl.py <model> <base_url> <category> "
+            "<num_threads> <temperature> <results_dir>"
+        )
+
+    model, base_url, category = sys.argv[1], sys.argv[2], sys.argv[3]
+    num_threads, temperature = int(sys.argv[4]), float(sys.argv[5])
+    results_dir = Path(sys.argv[6])
+
+    work_dir = (results_dir / ".bfcl_work").resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    parsed = urlparse(base_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 8000
+
+    os.environ["OPENAI_BASE_URL"] = base_url
+    os.environ["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY", "dummy")
+    os.environ["BFCL_PROJECT_ROOT"] = str(work_dir)
+    os.environ["LOCAL_SERVER_ENDPOINT"] = f"http://{host}"
+    os.environ["LOCAL_SERVER_PORT"] = str(port)
+
+    register_model(model, base_url)
+
+    print(f"[bfcl] generate: model={model} category={category}", flush=True)
+    run_generate(model, category, num_threads, temperature)
+
+    print(f"[bfcl] evaluate: model={model} category={category}", flush=True)
+    run_evaluate(model, category)
+
+    score = parse_score_from_csv(work_dir, model, category)
+    if not score:
+        sys.exit(f"[bfcl] no score found for {category}")
+
+    print(
+        f"[bfcl] {category}: accuracy={score.get('accuracy', '?')}",
+        flush=True,
+    )
+
+    out_dir = results_dir / f"bfcl-{category}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%dT%H-%M-%S")
+    out_path = out_dir / f"results_{ts}.json"
+
+    lm_eval_results = to_lm_eval_format(model, category, score)
+    with open(out_path, "w") as f:
+        json.dump(lm_eval_results, f, indent=2)
+
+    print(f"[bfcl] results written to {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/run_bfcl.py
+++ b/lib/run_bfcl.py
@@ -123,7 +123,7 @@ def parse_score_from_csv(work_dir: Path, model: str, category: str) -> dict | No
 
     # Fallback: look for per-category JSONL score files (older BFCL versions)
     model_slug = model.replace("/", "_")
-    for p in (work_dir / "score").rglob(f"{category}_score.json"):
+    for p in (work_dir / "score").rglob(f"*{category}_score.json"):
         with open(p) as f:
             return json.loads(f.readline())
 
@@ -173,7 +173,7 @@ def main():
     host = parsed.hostname or "localhost"
     port = parsed.port or 8000
 
-    os.environ["OPENAI_BASE_URL"] = base_url
+    os.environ["OPENAI_BASE_URL"] = base_url.rstrip("/") + "/v1"
     os.environ["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY", "dummy")
     os.environ["BFCL_PROJECT_ROOT"] = str(work_dir)
     os.environ["LOCAL_SERVER_ENDPOINT"] = f"http://{host}"

--- a/workloads/deepseek_v3_2_h200.yaml
+++ b/workloads/deepseek_v3_2_h200.yaml
@@ -34,6 +34,14 @@ lm_eval:
         max_length: 32768
         max_gen_toks: 4096
 
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
 vllm_bench:
   configs:
     - name: 8k-in-1k-out-conc-128


### PR DESCRIPTION
## Summary

- Adds a new `bfcl:` recipe block for running [BFCL](https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard) test categories against a live vLLM server
- Results are transformed to lm_eval-compatible JSON — zero changes to `ingest.py` or the dashboard. Scores auto-discover as `bfcl_<category>` tasks on ci.vllm.ai/eval
- Enables 4 non-live categories on the DeepSeek V3.2 workload (simple_python, multiple, parallel, parallel_multiple — ~1040 test cases)

### Files changed

| File | What |
|------|------|
| `lib/parse_workload.py` | Parse/validate `bfcl:` block, emit `BFCL_TSV` |
| `lib/run_bfcl.py` | New runner: register model in BFCL config, run generate+evaluate, transform output to lm_eval format |
| `lib/run.sh` | BFCL dispatch loop after lm_eval loop |
| `.buildkite/generate_pipeline.py` | Conditionally install `bfcl-eval soundfile` only for workloads with `bfcl:` block |
| `workloads/deepseek_v3_2_h200.yaml` | Add `bfcl:` block (already has `--enable-auto-tool-choice`) |
| `README.md` | Document `bfcl:` schema |

## Test plan

- [x] Parser smoke test — all 6 existing workloads parse without regression
- [x] Parser with `bfcl:` block — TSV output correct, validation catches missing serve_args
- [x] `bash -n` and `py_compile` pass on all modified files
- [x] BFCL prototype validated on H100 — Qwen3-8B, 4 categories, 1040 test cases, all passed
- [ ] Buildkite build with `WORKLOADS=deepseek_v3_2_h200` — end-to-end GPU validation

This PR was authored with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)