### PR TITLE
Add DeepSeek-V4-Flash GSM8K workload on B200

### DIFF
--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -35,15 +35,3 @@ lm_eval:
         num_concurrent: 64
         max_length: 32768
         max_gen_toks: 8192
-
-vllm_bench:
-  configs:
-    - name: 8k-in-1k-out-conc-128
-      backend: openai-chat
-      dataset: speed_bench
-      input_len: 8192
-      output_len: 1024
-      num_prompts: 512
-      max_concurrency: 128
-      speed_bench_dataset_subset: throughput_8k
-      speed_bench_category: low_entropy

--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -1,0 +1,49 @@
+# DeepSeek-V4-Flash on B200 (TP=2 × DP=4 + EP, deep_gemm_mega_moe, MTP spec-decode)
+name: deepseek_v4_flash-b200
+gpu: B200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: deepseek-ai/DeepSeek-V4-Flash
+  serve_args: >-
+    --tensor-parallel-size 2
+    --data-parallel-size 4
+    --enable-expert-parallel
+    --max-model-len 32768
+    --kv-cache-dtype fp8
+    --block-size 256
+    --moe-backend deep_gemm_mega_moe
+    --attention_config.use_fp4_indexer_cache=True
+    --tokenizer-mode deepseek_v4
+    --tool-call-parser deepseek_v4
+    --reasoning-parser deepseek_v4
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --speculative_config.method=mtp
+    --speculative_config.num_speculative_tokens=2
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai-chat
+      dataset: speed_bench
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      speed_bench_dataset_subset: throughput_8k
+      speed_bench_category: low_entropy


### PR DESCRIPTION
## Summary
- Add `deepseek_v4_flash_b200.yaml` — first B200 workload in perf-eval
- DeepSeek-V4-Flash with TP=2 × DP=4 + EP, `deep_gemm_mega_moe` backend, MTP speculative decoding (2 tokens)
- GSM8K 5-shot eval: **95.7% accuracy** (flexible-extract), exceeding the 95% threshold from [vllm/vllm#42111](https://github.com/vllm-project/vllm/pull/42111)

## Test plan
- [x] Parser smoke test passes locally
- [x] Buildkite build [#121](https://buildkite.com/vllm/perf-eval/builds/121) passed on B200 (`b200-k8s` queue)
- [x] Results ingested to perf dashboard

## Notes
- B200 image pulls require the ECR pull-through cache (`936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/...`) — direct `public.ecr.aws` pulls hit 429 rate limits
- `vllm_bench` omitted for now — `speed_bench` dataset depends on an external URL (`opencompass.openxlab.space`) unreachable from B200 k8s pods

This PR was authored with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)