### PR TITLE
Add gpt-oss-120b H200 workload

### DIFF
--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -1,0 +1,38 @@
+# GPT-OSS 120B on H200 (8xH200, TP=8)
+# Tracking perf regression: https://github.com/vllm-project/vllm/issues/40838
+name: gpt_oss_120b-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: openai/gpt-oss-120b
+  serve_args: >-
+    --tensor-parallel-size 8
+    --max-model-len 32768
+    --max-num-seqs 512
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai-chat
+      dataset: speed_bench
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      speed_bench_dataset_subset: throughput_8k
+      speed_bench_category: low_entropy

--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -11,6 +11,8 @@ vllm:
     --tensor-parallel-size 8
     --max-model-len 32768
     --max-num-seqs 512
+    --tool-call-parser openai
+    --enable-auto-tool-choice
 
 lm_eval:
   model_args:
@@ -24,6 +26,14 @@ lm_eval:
         num_concurrent: 64
         max_length: 32768
         max_gen_toks: 8192
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
 
 vllm_bench:
   configs:

--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -1,4 +1,4 @@
-# GPT-OSS 120B on H200 (8xH200, TP=8)
+# GPT-OSS 120B on H200 (8xH200, TP=4)
 # Tracking perf regression: https://github.com/vllm-project/vllm/issues/40838
 name: gpt_oss_120b-h200
 gpu: H200
@@ -8,7 +8,7 @@ nightly: true
 vllm:
   model: openai/gpt-oss-120b
   serve_args: >-
-    --tensor-parallel-size 8
+    --tensor-parallel-size 4
     --max-model-len 32768
     --max-num-seqs 512
     --tool-call-parser openai


### PR DESCRIPTION
## Summary

- Add nightly perf & eval recipe for `openai/gpt-oss-120b` on 8xH200 (TP=4)
- TP=4 matches the regression benchmark config from https://github.com/vllm-project/vllm/issues/40838 (~16% throughput drop v0.16→v0.19)
- gsm8k 5-shot accuracy eval + 8k-in/1k-out throughput bench
- BFCL tool-calling eval (simple_python, multiple, parallel, parallel_multiple)

## Test plan

- [x] Parser smoke test passes (`parse_workload.py` with stubbed lm_eval)
- [x] Shell syntax check passes (`bash -n lib/run.sh`)
- [x] Buildkite pipeline run validates end-to-end — [build #128 passed](https://buildkite.com/vllm/perf-eval/builds/128) (TP=8, prior to switch)
- [ ] Re-validate with TP=4 config
- [ ] Results appear on ci.vllm.ai dashboards

This PR was authored with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)