### PR TITLE
Add BFCL eval to all tool-calling-capable models

### DIFF
--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -23,6 +23,14 @@ vllm:
     --speculative_config.method=mtp
     --speculative_config.num_speculative_tokens=2
 
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
 lm_eval:
   model_args:
     tokenized_requests: false

--- a/workloads/deepseek_v4_pro_5_h200.yaml
+++ b/workloads/deepseek_v4_pro_5_h200.yaml
@@ -39,6 +39,14 @@ lm_eval:
         max_length: 32768
         max_gen_toks: 8192
 
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
 vllm_bench:
   configs:
     - name: 8k-in-1k-out-conc-128

--- a/workloads/glm_5_1_h200.yaml
+++ b/workloads/glm_5_1_h200.yaml
@@ -30,6 +30,14 @@ lm_eval:
         max_length: 40960
         max_gen_toks: 32768
 
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
 vllm_bench:
   configs:
     - name: 8k-in-1k-out-conc-128

--- a/workloads/kimi_k2_5_h200.yaml
+++ b/workloads/kimi_k2_5_h200.yaml
@@ -27,6 +27,14 @@ lm_eval:
         max_length: 40960
         max_gen_toks: 32768
 
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
 vllm_bench:
   configs:
     - name: 8k-in-1k-out-conc-128

--- a/workloads/minimax_m2_5_h200.yaml
+++ b/workloads/minimax_m2_5_h200.yaml
@@ -30,6 +30,14 @@ lm_eval:
         max_length: 40960
         max_gen_toks: 32768
 
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
 vllm_bench:
   configs:
     - name: 8k-in-1k-out-conc-128


### PR DESCRIPTION
## Summary

- Add BFCL tool-calling eval (simple_python, multiple, parallel, parallel_multiple) to 5 models that already have `--tool-call-parser` and `--enable-auto-tool-choice`:
  - DeepSeek V4 Pro (H200)
  - DeepSeek V4 Flash (B200)
  - GLM 5.1 (H200)
  - Kimi K2.5 (H200)
  - MiniMax M2.5 (H200)
- DSv3.2 and gpt-oss-120b already have BFCL (from PRs #7 and #9)
- Qwen3.5 and Nemotron Super don't support tool calling, so they're excluded

## Test plan

- [x] Parser smoke test passes for all 5 modified recipes
- [ ] Buildkite pipeline validates end-to-end
- [ ] BFCL results appear on ci.vllm.ai/eval for each model

This PR was authored with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)