### PR TITLE
Use ECR pull-through cache for B200 K8s pod images

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -59,6 +59,18 @@ GPU_EMOJI = {
     "A100": ":a100:",
 }
 
+ECR_PUBLIC_PREFIX = "public.ecr.aws/"
+ECR_PULL_THROUGH_CACHE = (
+    "936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/"
+)
+
+
+def ecr_pull_through(image):
+    """Rewrite public ECR URLs to the private pull-through cache."""
+    if image.startswith(ECR_PUBLIC_PREFIX):
+        return ECR_PULL_THROUGH_CACHE + image[len(ECR_PUBLIC_PREFIX):]
+    return image
+
 
 def is_truthy(value):
     return str(value or "").lower() in {"1", "true", "yes"}
@@ -179,7 +191,7 @@ def make_step(path, data, profiles):
         "artifact_paths": ["results/**/*"],
     }
     if profile.get("server_runtime") == "native":
-        step["plugins"] = [b200_k8s_plugin(resolved_image(data), data.get("num_gpus", 1))]
+        step["plugins"] = [b200_k8s_plugin(ecr_pull_through(resolved_image(data)), data.get("num_gpus", 1))]
     step_env = {
         k: os.environ[k]
         for k in ("VLLM_IMAGE", "VLLM_COMMIT", "BENCH_ONLY")


### PR DESCRIPTION
## Summary
- B200 K8s jobs pull container images from `public.ecr.aws`, which hit **429 Too Many Requests** rate limits causing `ImagePullBackOff` failures (e.g. build #130)
- Rewrites `public.ecr.aws/` URLs to the private ECR pull-through cache (`936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/`) for K8s pod specs — the same cache CI already uses for its K8s jobs
- Non-ECR images (Docker Hub) and non-K8s steps (H200) are unaffected

## Test plan
- [x] Verified B200 step generates rewritten image URL in pod spec
- [x] Verified H200 steps are unaffected (no `plugins` section)
- [x] Verified Docker Hub images pass through unchanged
- [x] Python syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)