### PR TITLE
[BFCL] Add multiturn test group for tool accuracy 

### DIFF
--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -29,6 +29,7 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
+    - multi_turn
   num_threads: 8
 
 lm_eval:

--- a/workloads/deepseek_v4_pro_5_h200.yaml
+++ b/workloads/deepseek_v4_pro_5_h200.yaml
@@ -45,6 +45,7 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
+    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/glm_5_1_h200.yaml
+++ b/workloads/glm_5_1_h200.yaml
@@ -36,6 +36,7 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
+    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -33,6 +33,7 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
+    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/kimi_k2_5_h200.yaml
+++ b/workloads/kimi_k2_5_h200.yaml
@@ -33,6 +33,7 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
+    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/minimax_m2_5_h200.yaml
+++ b/workloads/minimax_m2_5_h200.yaml
@@ -36,6 +36,7 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
+    - multi_turn
   num_threads: 8
 
 vllm_bench:


### PR DESCRIPTION
BFCL `multi_turn` test group measures how accurately an LLM uses tools  in back-and-forth conversational settings, tracking context and dynamically correcting parameters over multiple turn

Below are  multi-turn test categories:

```
multi_turn_base: Base entries for multi-turn function calls.
multi_turn_miss_func: Multi-turn function calls with missing function.
multi_turn_miss_param: Multi-turn function calls with missing parameter.
multi_turn_long_context: Multi-turn function calls with long context.
```