### PR TITLE
Revert "[BFCL] Add multiturn test group for tool accuracy" (#15)

### DIFF
--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -29,7 +29,6 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
-    - multi_turn
   num_threads: 8
 
 lm_eval:

--- a/workloads/deepseek_v4_pro_5_h200.yaml
+++ b/workloads/deepseek_v4_pro_5_h200.yaml
@@ -45,7 +45,6 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
-    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/glm_5_1_h200.yaml
+++ b/workloads/glm_5_1_h200.yaml
@@ -36,7 +36,6 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
-    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -33,7 +33,6 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
-    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/kimi_k2_5_h200.yaml
+++ b/workloads/kimi_k2_5_h200.yaml
@@ -33,7 +33,6 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
-    - multi_turn
   num_threads: 8
 
 vllm_bench:

--- a/workloads/minimax_m2_5_h200.yaml
+++ b/workloads/minimax_m2_5_h200.yaml
@@ -36,7 +36,6 @@ bfcl:
     - multiple
     - parallel
     - parallel_multiple
-    - multi_turn
   num_threads: 8
 
 vllm_bench:


### PR DESCRIPTION
Reverts #15.

The `multi_turn` BFCL category broke the `glm_5_1-h200` and `gpt_oss_120b-h200` jobs in both nightly runs since it landed ([build 191](https://buildkite.com/vllm/perf-eval/builds/191), [build 193](https://buildkite.com/vllm/perf-eval/builds/193)). The eval itself completes (800/800 samples generated and scored, ~52 min on GLM), but `lib/run_bfcl.py` then exits 1 with `[bfcl] no score found for multi_turn`:

- `multi_turn` is an *aggregate* category spanning four sub-categories. `CATEGORY_TO_CSV` only maps the sub-categories (`multi_turn_base`, `_miss_func`, `_miss_param`, `_long_context`), so the parser falls through to `data_overall.csv`, which has no `BFCL_v4_multi_turn` column.
- The fallback glob `*multi_turn_score.json` doesn't match the per-sub-category files BFCL actually writes (`BFCL_v4_multi_turn_base_score.json` etc.).

Reverting until the score parser supports aggregate categories; re-landing should pair the workload change with a `run_bfcl.py` fix.

(The `deepseek_v4_flash-b200` failure in those builds is unrelated — tilelang JIT can't find CCCL headers — and is not addressed here.)

This PR was authored with assistance from Claude Code.