### PR TITLE
[BFCL] Remove  parallel tool calling test from gpt-oss model

### DIFF
--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -31,8 +31,6 @@ bfcl:
   test_categories:
     - simple_python
     - multiple
-    - parallel
-    - parallel_multiple
     - multi_turn
   num_threads: 8
 


### PR DESCRIPTION
GPT-OSS models do not support parallel tool calling because of the Harmony format(without going inot more in depth technically) . As a result, they achieve 0% accuracy on BFCL for parallel test, so I think it is better to exclude them from the benchmark.


<img width="1366" height="559" alt="image" src="https://github.com/user-attachments/assets/32702efd-0c94-404c-8c6b-0630e68563e3" />

