### PR TITLE
[ROCm] Don't use VLLM_IMAGE on AMD unless it is a ROCm image

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -96,7 +96,8 @@ def resolved_image(data, profile):
     override_commit = (os.environ.get("VLLM_COMMIT") or "").strip()
     custom_repo = (profile.get("image_repo") or "").strip()
     repo = custom_repo or DEFAULT_IMAGE_REPO
-    if override_image:
+    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
+    if override_image and (not custom_repo or "rocm" in override_image.lower()):
         return override_image
     commit = override_commit or commit_from_image(override_image)
     if commit:

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -96,8 +96,8 @@ def resolve_image(vllm: dict, profile: dict) -> tuple[str, str]:
     # images (CUDA) are stored at vllm/vllm-openai
     custom_repo = (profile.get("image_repo") or "").strip()
     repo = custom_repo or "vllm/vllm-openai"
-
-    if override_image:
+    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
+    if override_image and (not custom_repo or "rocm" in override_image.lower()):
         return override_image, override_commit or commit_from_image(override_image)
 
     commit = override_commit or commit_from_image(override_image)


### PR DESCRIPTION
We saw in the nightly that the AMD workloads were failing https://buildkite.com/vllm/perf-eval/builds/209

The nightly Buildkite is running with VLLM_IMAGE set to an Nvidia image, and the AMD workloads were trying to use it. Here we change the default behavior to ignore VLLM_IMAGE if it is not a ROCm image, and instead resolve the image tag using VLLM_COMMIT like `vllm/vllm-openai-rocm:nightly-<VLLM_COMMIT>`. 