### PR TITLE
Add MiniMax-M3 Nightly Perf & Accuracy Regression Testing on MI355X with EAGLE3 spec decode

### DIFF
--- a/workloads/minimax_m3_mi355x.yaml
+++ b/workloads/minimax_m3_mi355x.yaml
@@ -1,0 +1,56 @@
+# MiniMax-M3 on MI355X (CDNA4) with EAGLE3 speculative decode
+#
+# MXFP8 checkpoint runs natively on CDNA4 (OCP fp8 + MX matrix cores).
+# EAGLE3 drafter: Inferact/MiniMax-M3-EAGLE3 (LlamaForCausalLMEagle3 head,
+# hidden_size 6144 / vocab 200064 matching the M3 target), drafting 3 tokens.
+#
+# KV cache is intentionally left at the model default (bf16). MiniMax-M3-MXFP8
+# ships no calibrated KV scales, so --kv-cache-dtype fp8 silently falls back to
+# scale 1.0 and corrupts output (see vllm-project/vllm#45562); do not enable it
+# here without a calibrated checkpoint or a self-calibrating dtype.
+name: minimax_m3-mi355x
+gpu: MI355X
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  env:
+    VLLM_USE_BREAKABLE_CUDAGRAPH: 0
+  serve_args: >-
+    --tensor-parallel-size 8
+    --tool-call-parser minimax_m3
+    --reasoning-parser minimax_m3
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --speculative-config.method eagle3
+    --speculative-config.model Inferact/MiniMax-M3-EAGLE3
+    --speculative-config.num_speculative_tokens 3
+
+lm_eval:
+  # gsm8k here is a correctness gate: speculative decoding is output-equivalent
+  # to non-spec greedy, so the score must match the no-spec MiniMax-M3 baseline.
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+vllm_bench:
+  # random + openai backend (no speed_bench): speed_bench needs
+  # --skip-tokenizer-init, which caps every request at 1 output token so
+  # throughput reads ~0. See https://github.com/vllm-project/perf-eval/pull/20
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128

--- a/workloads/minimax_m3_mi355x.yaml
+++ b/workloads/minimax_m3_mi355x.yaml
@@ -8,6 +8,12 @@
 # ships no calibrated KV scales, so --kv-cache-dtype fp8 silently falls back to
 # scale 1.0 and corrupts output (see vllm-project/vllm#45562); do not enable it
 # here without a calibrated checkpoint or a self-calibrating dtype.
+#
+# --block-size 128 is required: with EAGLE3 spec decode on this backend the
+# default KV-manager block size (16) has no compatible attention-kernel block
+# size, so bring-up dies in select_common_block_size with
+# "No common block size for 16." Forcing 128 gives a block size every kernel
+# in the spec-decode path supports.
 name: minimax_m3-mi355x
 gpu: MI355X
 num_gpus: 8
@@ -19,6 +25,7 @@ vllm:
     VLLM_USE_BREAKABLE_CUDAGRAPH: 0
   serve_args: >-
     --tensor-parallel-size 8
+    --block-size 128
     --tool-call-parser minimax_m3
     --reasoning-parser minimax_m3
     --enable-auto-tool-choice


### PR DESCRIPTION
## Summary

Adds `workloads/minimax_m3_mi355x.yaml` — a new recipe running **MiniMax-M3-MXFP8 on MI355X (CDNA4)** with **EAGLE3 speculative decode**.

+viz @hongxiayang @andyluo7 @chunfangamd @micah-wil

**Serving config**
- Model `MiniMaxAI/MiniMax-M3-MXFP8` (MXFP8 runs natively on CDNA4 — OCP fp8 + MX matrix cores), `num_gpus: 8`.
- `--tensor-parallel-size 8`, **no expert parallelism** (EP's all-to-all overhead hurts the low-latency decode path that speculation targets).
- **No `--max-model-len`** — uses the model default, consistent with the other MI355X recipes.
- `minimax_m3` tool-call + reasoning parsers with `--enable-auto-tool-choice`, `--trust-remote-code`.
- env: `VLLM_USE_BREAKABLE_CUDAGRAPH=0` per @hongxiayang https://github.com/vllm-project/recipes/pull/539

**EAGLE3 speculative decode**
- `--speculative-config.method eagle3`, drafter `--speculative-config.model Inferact/MiniMax-M3-EAGLE3`,  `--speculative-config.num_speculative_tokens 3`.

**Evals**
- **`lm_eval` gsm8k** (5-shot) as the spec-decode correctness gate: speculative decoding is output-equivalent to non-spec greedy, so the score must match the no-spec MiniMax-M3 baseline.
- **`vllm_bench`** — a single `8k-in/1k-out` config at conc-128 (MI355X-family baseline) for the decode-throughput uplift, using `random` + `backend: openai` (not `speed_bench` per https://github.com/vllm-project/perf-eval/pull/20).

## ⛔ Blocked — draft / do not merge yet

`nightly: true` (runs in the nightly schedule), but this is **blocked on vllm-project/vllm#45381** (MiniMax-M3 support) landing on `main`, which carries the **ROCm/AMD EAGLE3 enablement (#45546)**. Until that merges, the `vllm-openai-rocm` image cannot serve M3 + AMD EAGLE3, so **the nightly run will fail at server bring-up until #45381 is on main** (red nights are expected). Kept as a GitHub draft until it goes green.

**Green checklist**
- [x] vllm-project/vllm#45381 merged to `main` (includes https://github.com/vllm-project/vllm/pull/45546 ROCm EAGLE3)
- [x] wait for @micah-wil 's PR to merge https://github.com/vllm-project/perf-eval/pull/23
- [ ] Mark PR ready for review

## Notes

- **KV cache deliberately left at the model default (bf16).** `MiniMax-M3-MXFP8` ships no calibrated KV scales, so `--kv-cache-dtype fp8` silently falls back to scale 1.0 and corrupts output (vllm-project/vllm#45562). Don't enable fp8 KV here without a calibrated checkpoint or a self-calibrating dtype.
- **Perf bench uses `random` + `openai`, not `speed_bench`.** `speed_bench` requires `--skip-tokenizer-init`, which caps every request at 1 output token so throughput reads ~0; this recipe follows vllm-project/perf-eval#20 (and drops the now-vestigial `speed_bench_*` fields the other MI355X recipes still carry).
- No README/schema change — the pipeline auto-discovers `workloads/*.yaml`.

## Validation

- Parser smoke test (per `CLAUDE.md`, stubbed `lm_eval` registry) passes: name/image/model/serve_args/env and the `lm_eval` + `vllm_bench` TSVs all resolve correctly. Device=`mi355x`, TP=8, precision=`fp8`.
- No real GPU run yet (blocked, see above).

## AI assistance

This PR was authored with assistance from Claude Code (AI-assisted). The commit carries a `Co-Authored-By: Claude` trailer.
