### PR TITLE
Add MiniMax M3 B200 workload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,12 @@ If you actually need real validation (parser hitting lm-eval's task registry rat
 
 ## Launching a Buildkite build
 
-Use the Buildkite MCP tools — never shell out to `curl` or `bk`. Pipeline metadata:
+Use either the Buildkite MCP tools or an authenticated `bk` CLI. Prefer MCP
+when it is available because its responses are already structured; `bk` is a
+supported alternative for triggering, watching, and inspecting builds. Never
+make raw Buildkite API calls with `curl`.
+
+Pipeline metadata:
 
 - **org**: `vllm`
 - **pipeline**: `perf-eval`
@@ -55,20 +60,50 @@ Use the Buildkite MCP tools — never shell out to `curl` or `bk`. Pipeline meta
 ### Workflow
 
 1. **Make sure the commit is on the remote.** Buildkite clones from GitHub; unpushed commits will fail to resolve. If the user has local changes you've been working on, ask before pushing; once pushed, capture the SHA from `git rev-parse <branch>`.
-2. **Trigger the build** via `mcp__claude_ai_Buildkite__create_build`:
+2. **Trigger the build** with either MCP or `bk`.
+
+   With `mcp__claude_ai_Buildkite__create_build`:
+
    - `org_slug: "vllm"`
    - `pipeline_slug: "perf-eval"`
    - `commit: "<full SHA>"`
    - `branch: "<branch name>"` (use the actual branch, not `main`, when testing a feature branch)
    - `message: "<short description of what this tests>"` — match the existing convention: short, action-oriented (e.g. "Add gpqa diamond", "Writable HF_HOME for lm_eval datasets cache"). No emoji unless the user asks.
    - `environment`: always pass both `VLLM_COMMIT` (the vLLM SHA being tested) and `VLLM_IMAGE` (the full Docker image URI). Optionally pass `WORKLOADS` for an explicit workload list; omit it to run all `nightly: true` workloads.
-3. **Report the build URL** back to the user immediately so they can follow along; the response includes `web_url`.
+
+   With `bk` (run `bk auth status` first):
+
+   ```bash
+   bk build create \
+     --yes \
+     --pipeline vllm/perf-eval \
+     --commit "<full perf-eval SHA>" \
+     --branch "<branch name>" \
+     --message "<short description of what this tests>" \
+     --env "VLLM_COMMIT=<vLLM SHA>" \
+     --env "VLLM_IMAGE=<full Docker image URI>" \
+     --env "WORKLOADS=<optional workload list>"
+   ```
+
+   Omit the final `WORKLOADS` argument to run every `nightly: true` workload.
+3. **Report the build URL** back to the user immediately so they can follow
+   along. MCP returns it as `web_url`; `bk build create` prints it in the build
+   summary.
 
 ### Watching a running build
 
 - `mcp__claude_ai_Buildkite__get_build` with `job_state: "failed,broken,canceled"` to check for failures without pulling full logs.
 - `mcp__claude_ai_Buildkite__tail_logs` with the `job_id` for the most recent log lines — start here for failure diagnosis, it's far cheaper than `read_logs`.
 - `mcp__claude_ai_Buildkite__search_logs` with patterns like `"error|failed|exception|Traceback"` if `tail_logs` doesn't show the failure.
+
+With `bk`, watch the build, inspect its structured summary to identify failed
+job IDs, and then pull only the relevant job log:
+
+```bash
+bk build watch <build-number> --pipeline vllm/perf-eval
+bk build view <build-number> --pipeline vllm/perf-eval --json
+bk job log <job-id>
+```
 
 A typical build takes ~30–90 minutes (the step has a 120-min hard timeout) — it downloads model weights into the workload GPU profile's HF cache, then runs every task in the workload. GPU queues are shared with other vLLM pipelines, so don't trigger duplicate builds for the same commit unless asked.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,8 @@ With `bk`, watch the build, inspect its structured summary to identify failed
 job IDs, and then pull only the relevant job log:
 
 ```bash
-bk build watch <build-number> --pipeline vllm/perf-eval
-bk build view <build-number> --pipeline vllm/perf-eval --json
+bk build watch <build-number> --pipeline perf-eval
+bk build view <build-number> --pipeline perf-eval --json
 bk job log <job-id>
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ job IDs, and then pull only the relevant job log:
 ```bash
 bk build watch <build-number> --pipeline perf-eval
 bk build view <build-number> --pipeline perf-eval --json
-bk job log <job-id>
+bk job log <job-id> --pipeline perf-eval --build-number <build-number>
 ```
 
 A typical build takes ~30–90 minutes (the step has a 120-min hard timeout) — it downloads model weights into the workload GPU profile's HF cache, then runs every task in the workload. GPU queues are shared with other vLLM pipelines, so don't trigger duplicate builds for the same commit unless asked.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ CLAUDE.md         agent conventions and detailed Buildkite workflow
 
 ### Add a new recipe
 
-1. Copy an existing workload that targets the same GPU — e.g. `workloads/qwen3_5_h200.yaml` is a small, complete example.
+1. Copy an existing workload that targets the same GPU — e.g. `workloads/qwen3_5_h200.yaml` for H200 or `workloads/minimax_m3_b200.yaml` for B200.
 2. Name the file `<model>_<hardware>.yaml`. Keep hardware variants in separate files.
 3. Edit the fields to match your model and tasks. Set `nightly: true` if it should run in the nightly schedule; leave it off for opt-in recipes.
 4. Open a PR. The pipeline auto-discovers `workloads/*.yaml` — no Buildkite YAML edits needed.
+
+B200 workloads run in a single Kubernetes pod. `num_gpus` controls the pod's
+GPU allocation; use at most 8 GPUs to keep the workload on one B200 node.
 
 ### Recipe schema
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ The pipeline is [**`vllm/perf-eval`**](https://buildkite.com/vllm/perf-eval). Wi
 
 This runs the `qwen3_5_h200` workload against the specified vLLM nightly image. Omit `WORKLOADS` to run all `nightly: true` workloads.
 
-**From an agent:** see `CLAUDE.md` for the Buildkite MCP workflow (don't shell out to `curl` or `bk`).
+**From an agent:** see `CLAUDE.md` for the Buildkite MCP and authenticated
+`bk` workflows. Don't make raw Buildkite API calls with `curl`.
 
 ### Run a recipe end-to-end
 

--- a/lib/run_vllm_bench.sh
+++ b/lib/run_vllm_bench.sh
@@ -115,14 +115,14 @@ run_vllm_bench() {
       [[ -n "$speed_bench_category" ]] && data_dir="${data_dir}-${speed_bench_category}"
       prepare_speed_bench_dataset "$container" "$runtime" \
         "$speed_bench_dataset_subset" "$speed_bench_category" "$data_dir"
-      # SPEED-Bench needs a tokenizer to load the dataset and count prompt
-      # tokens, but applying a client-side chat template breaks models that do
-      # not define one. Keep tokenizer initialization and skip only templating.
+      # SPEED-Bench applies the client-side chat template at tokenizer init,
+      # which breaks for chat-template-less models — rely on server-side
+      # usage accounting instead.
       cmd+=(
         --dataset-path "$data_dir"
         --speed-bench-output-len "$output_len"
         --speed-bench-dataset-subset "$speed_bench_dataset_subset"
-        --skip-chat-template
+        --skip-tokenizer-init
       )
       [[ -n "$speed_bench_category" ]] && cmd+=(--speed-bench-category "$speed_bench_category")
       ;;

--- a/lib/run_vllm_bench.sh
+++ b/lib/run_vllm_bench.sh
@@ -115,14 +115,14 @@ run_vllm_bench() {
       [[ -n "$speed_bench_category" ]] && data_dir="${data_dir}-${speed_bench_category}"
       prepare_speed_bench_dataset "$container" "$runtime" \
         "$speed_bench_dataset_subset" "$speed_bench_category" "$data_dir"
-      # SPEED-Bench applies the client-side chat template at tokenizer init,
-      # which breaks for chat-template-less models — rely on server-side
-      # usage accounting instead.
+      # SPEED-Bench needs a tokenizer to load the dataset and count prompt
+      # tokens, but applying a client-side chat template breaks models that do
+      # not define one. Keep tokenizer initialization and skip only templating.
       cmd+=(
         --dataset-path "$data_dir"
         --speed-bench-output-len "$output_len"
         --speed-bench-dataset-subset "$speed_bench_dataset_subset"
-        --skip-tokenizer-init
+        --skip-chat-template
       )
       [[ -n "$speed_bench_category" ]] && cmd+=(--speed-bench-category "$speed_bench_category")
       ;;

--- a/workloads/minimax_m3_b200.yaml
+++ b/workloads/minimax_m3_b200.yaml
@@ -1,10 +1,11 @@
 # MiniMax-M3 NVFP4 on B200
 # Recipe: https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3
-# The recipe's verified Blackwell baseline is single-node TP=8. This workload
-# is text-only and caps context at 32K to leave KV-cache headroom for evals.
+# The recipe's verified Blackwell baseline is single-node TP=8, but the NVFP4
+# checkpoint fits on two B200s. Use TP=2 to reduce tensor-parallel overhead.
+# This workload is text-only and caps context at 32K for KV-cache headroom.
 name: minimax_m3-b200
 gpu: B200
-num_gpus: 8
+num_gpus: 2
 nightly: true
 
 vllm:
@@ -13,7 +14,7 @@ vllm:
   env:
     VLLM_FLOAT32_MATMUL_PRECISION: high
   serve_args: >-
-    --tensor-parallel-size 8
+    --tensor-parallel-size 2
     --trust-remote-code
     --block-size 128
     --language-model-only
@@ -31,7 +32,7 @@ lm_eval:
     - name: gsm8k
       num_fewshot: 5
       model_args:
-        num_concurrent: 64
+        num_concurrent: 16
         max_length: 32768
         max_gen_toks: 8192
 
@@ -45,10 +46,10 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out-conc-16
       backend: openai-chat
       dataset: random
       input_len: 8192
       output_len: 1024
       num_prompts: 512
-      max_concurrency: 128
+      max_concurrency: 16

--- a/workloads/minimax_m3_b200.yaml
+++ b/workloads/minimax_m3_b200.yaml
@@ -47,10 +47,8 @@ vllm_bench:
   configs:
     - name: 8k-in-1k-out-conc-128
       backend: openai-chat
-      dataset: speed_bench
+      dataset: random
       input_len: 8192
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
-      speed_bench_dataset_subset: throughput_8k
-      speed_bench_category: low_entropy

--- a/workloads/minimax_m3_b200.yaml
+++ b/workloads/minimax_m3_b200.yaml
@@ -1,0 +1,56 @@
+# MiniMax-M3 NVFP4 on B200
+# Recipe: https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3
+# The recipe's verified Blackwell baseline is single-node TP=8. This workload
+# is text-only and caps context at 32K to leave KV-cache headroom for evals.
+name: minimax_m3-b200
+gpu: B200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: nvidia/MiniMax-M3-NVFP4
+  image: vllm/vllm-openai:minimax-m3
+  env:
+    VLLM_FLOAT32_MATMUL_PRECISION: high
+  serve_args: >-
+    --tensor-parallel-size 8
+    --trust-remote-code
+    --block-size 128
+    --language-model-only
+    --max-model-len 32768
+    --tool-call-parser minimax_m3
+    --reasoning-parser minimax_m3
+    --enable-auto-tool-choice
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai-chat
+      dataset: speed_bench
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      speed_bench_dataset_subset: throughput_8k
+      speed_bench_category: low_entropy


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary

- add a nightly MiniMax M3 workload using the recipe's B200-validated NVFP4 checkpoint
- run single-node TP8 with the required MSA block size and MiniMax M3 tool/reasoning parsers
- use text-only serving with a 32K context cap for eval and KV-cache headroom
- benchmark 8K-input/1K-output serving at concurrency 128 with the random dataset
- document the single-pod, up-to-8-GPU B200 convention in the README
- allow authenticated `bk` as a supported alternative to the Buildkite MCP tools while keeping raw `curl` API calls disallowed

## Validation

- parser smoke test with a stubbed `gsm8k` registry
- generated-pipeline assertions for the `b200-k8s` queue, 8-GPU allocation, image override, and workload path
- random benchmark command smoke test verifies the 8192-token input, 1024-token output, and result validation path
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `git diff --check`
- verified the documented `bk build create`, `watch`, `view`, and `job log` flags against the installed CLI and exercised them against live builds

## GPU validation

Passed: https://buildkite.com/vllm/perf-eval/builds/288

- result: full `:b200: minimax_m3-b200` step passed in 30m35s
- topology: one B200 node with 8 GPUs, TP8
- perf-eval commit: `2f8bde0f7916227e4a2452e381894f51c7032347`
- branch: `codex/add-minimax-m3-b200`
- `WORKLOADS=minimax_m3_b200`
- `VLLM_COMMIT=94c0ef300180f8fd1071d9cbe7270a8348155f94`
- `VLLM_IMAGE=vllm/vllm-openai:nightly-94c0ef300180f8fd1071d9cbe7270a8348155f94`

[Build #286](https://buildkite.com/vllm/perf-eval/builds/286) established that the model starts successfully on one 8×B200 worker: vLLM resolved MiniMax M3, formed the TP8 world, loaded NVFP4 weights, selected the MSA/Blackwell kernels, and became healthy. It then failed in Python SpeedBench tokenizer initialization.

[Build #287](https://buildkite.com/vllm/perf-eval/builds/287) cleared that tokenizer failure and prepared all 512 SpeedBench samples, then exposed that the image lacks SpeedBench's optional pandas runtime dependency. Because this pipeline uses Python `vllm bench serve`, not the Rust `vllm-bench`, the workload now uses the random dataset instead. Build #288 validates that configuration end-to-end.