### PR TITLE
Default k8s HF cache to emptyDir; make volume source overridable

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -105,7 +105,7 @@ def resolved_image(data, profile):
     return vllm.get("image", f"{repo}:nightly")
 
 
-def b200_k8s_plugin(image, num_gpus, profile=None):
+def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
     return {
         "kubernetes": {
             "podSpec": {
@@ -161,7 +161,27 @@ def b200_k8s_plugin(image, num_gpus, profile=None):
     }
 
 
-def amd_k8s_plugin(image, num_gpus, profile=None):
+def hf_cache_volume(gpu, profile):
+    """Resolve the Kubernetes volume backing the HF cache for a k8s plugin.
+
+    The source is per-cluster, so it can be overridden by a ``{GPU}_HF_CACHE_VOLUME``
+    env var (JSON, minus the ``name`` key) — the same override idiom as
+    ``{GPU}_QUEUE`` — or set in the profile's ``hf_cache_volume``. It defaults to
+    an ``emptyDir``: the cache is scoped to the pod, so it is reclaimed when the
+    benchmark pod exits and can never accumulate on the node's disk. Clusters that
+    want a warm, cross-run cache point this at their own PVC (or a real hostPath
+    mount) via the override — the pod's ``HF_HOME`` mount path is unchanged either
+    way, so only cross-run persistence differs.
+    """
+    override = (os.environ.get(f"{gpu.upper()}_HF_CACHE_VOLUME") or "").strip()
+    if override:
+        source = yaml.safe_load(override)
+    else:
+        source = profile.get("hf_cache_volume") or {"emptyDir": {}}
+    return {"name": "hf-cache", **source}
+
+
+def amd_k8s_plugin(image, num_gpus, profile=None, gpu=None):
     profile = profile or {}
     hf_home = profile.get("hf_home") or "/root/.cache/huggingface"
     return {
@@ -200,10 +220,7 @@ def amd_k8s_plugin(image, num_gpus, profile=None):
                 ],
                 "volumes": [
                     {"name": "devshm", "emptyDir": {"medium": "Memory"}},
-                    {
-                        "name": "hf-cache",
-                        "hostPath": {"path": hf_home, "type": "DirectoryOrCreate"},
-                    },
+                    hf_cache_volume(gpu, profile),
                 ],
             },
         },
@@ -274,7 +291,7 @@ def make_step(path, data, profiles):
         if builder is None:
             sys.exit(f"{path}: unknown k8s_plugin {kind!r} (have {', '.join(K8S_PLUGINS)})")
         image = ecr_pull_through(resolved_image(data, profile))
-        step["plugins"] = [builder(image, data.get("num_gpus", 1), profile)]
+        step["plugins"] = [builder(image, data.get("num_gpus", 1), profile, gpu)]
     step_env = {
         k: os.environ[k]
         for k in ("VLLM_IMAGE", "VLLM_COMMIT", "BENCH_ONLY")

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Stdlib-only regression tests for generate_pipeline.py.
+
+Run with ``python3 .buildkite/test_generate_pipeline.py`` (needs only pyyaml,
+which the pipeline already installs). No pytest / GPU / network required.
+
+Guards the HF-cache volume behaviour: the AMD k8s plugin must NOT emit a
+root-disk hostPath by default (that leaked model caches onto node root disks),
+and the volume source must be overridable per-cluster.
+"""
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "generate_pipeline", os.path.join(HERE, "generate_pipeline.py")
+)
+g = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(g)
+
+
+def _amd_volumes(profile, gpu="MI300X"):
+    plugin = g.amd_k8s_plugin("img", 8, profile, gpu)
+    patch = plugin["kubernetes"]["podSpecPatch"]
+    vols = {v["name"]: v for v in patch["volumes"]}
+    return patch, vols
+
+
+def test_default_hf_cache_is_emptydir_not_hostpath():
+    """Default (no override, no profile field) must be an emptyDir, never a
+    hostPath — a hostPath on an unmounted node path is what filled root disks."""
+    _, vols = _amd_volumes({})
+    hf = vols["hf-cache"]
+    assert "emptyDir" in hf, f"expected emptyDir default, got {hf}"
+    assert "hostPath" not in hf, f"default must not be a hostPath: {hf}"
+
+
+def test_hf_home_mount_matches_env():
+    """Whatever the volume source, the mount path and HF_HOME must agree so vLLM
+    finds its cache at the advertised location."""
+    patch, vols = _amd_volumes({"hf_home": "/root/.cache/huggingface"})
+    c = patch["containers"][0]
+    mount = next(m for m in c["volumeMounts"] if m["name"] == "hf-cache")
+    hf_home = next(e for e in c["env"] if e["name"] == "HF_HOME")
+    assert mount["mountPath"] == hf_home["value"] == "/root/.cache/huggingface"
+
+
+def test_profile_field_overrides_source():
+    """A profile-level hf_cache_volume sets the source but keeps the volume name."""
+    pvc = {"persistentVolumeClaim": {"claimName": "hf-cache-pvc"}}
+    _, vols = _amd_volumes({"hf_cache_volume": pvc})
+    assert vols["hf-cache"] == {"name": "hf-cache", **pvc}
+
+
+def test_env_override_wins_over_profile_and_default():
+    """{GPU}_HF_CACHE_VOLUME (per-cluster) overrides the profile and default."""
+    key = "MI355X_HF_CACHE_VOLUME"
+    prev = os.environ.get(key)
+    os.environ[key] = '{"persistentVolumeClaim":{"claimName":"buildkite-hf-cache"}}'
+    try:
+        _, vols = _amd_volumes(
+            {"hf_cache_volume": {"emptyDir": {}}}, gpu="MI355X"
+        )
+    finally:
+        if prev is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prev
+    assert vols["hf-cache"] == {
+        "name": "hf-cache",
+        "persistentVolumeClaim": {"claimName": "buildkite-hf-cache"},
+    }
+
+
+def test_env_override_is_scoped_per_gpu():
+    """An override for one GPU key must not leak into another GPU's volume."""
+    key = "MI300X_HF_CACHE_VOLUME"
+    prev = os.environ.get(key)
+    os.environ[key] = '{"persistentVolumeClaim":{"claimName":"only-mi300"}}'
+    try:
+        _, vols = _amd_volumes({}, gpu="MI355X")
+    finally:
+        if prev is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prev
+    assert "emptyDir" in vols["hf-cache"], vols["hf-cache"]
+
+
+def test_shipped_amd_profiles_have_no_rootdisk_hostpath():
+    """The committed MI300X/MI355X profiles must not reintroduce an hf_home under
+    /mnt/shared (the concrete path that leaked onto root disks)."""
+    profiles = g.load_profiles()
+    for gpu in ("MI300X", "MI355X"):
+        hf_home = (profiles.get(gpu) or {}).get("hf_home") or ""
+        assert not hf_home.startswith("/mnt/shared"), (
+            f"{gpu} hf_home={hf_home!r} would land on the node root disk"
+        )
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+.hf-cache/
+results/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Each recipe is one `(model, hardware, set of tasks)` combination. The Buildkite 
 ```
 workloads/        one YAML per (model, hardware) recipe
 lib/              orchestrator (run.sh), helpers, GPU profiles
-.buildkite/       pipeline bootstrap and step generator
+.buildkite/       pipeline bootstrap, step generator, and its tests
 CLAUDE.md         agent conventions and detailed Buildkite workflow
 ```
 
@@ -98,6 +98,24 @@ A few things worth knowing:
 - **`bfcl.max_test_cases`** subsamples a category instead of running the full set — e.g. `multi_turn` (~800 cases) down to 300. For aggregate groups with multiple subcategories, the cap is split evenly across subcategories (by BFCL id order within each). Set a single integer to cap every category, or a map per category (`multi_turn: 240`). Override per-run with `BFCL_MAX_TEST_CASES`. Scores are partial-eval only and are not comparable to full BFCL leaderboard numbers.
 
 For everything else (the full set of supported fields, defaults, validation rules), the existing files in `workloads/` are the working reference and `lib/parse_workload.py` is the source of truth.
+
+### HF cache volume (Kubernetes profiles)
+
+For profiles that run in-pod on Kubernetes (`server_runtime: native` with a `k8s_plugin`), the HuggingFace cache is a named `hf-cache` volume mounted at the profile's `hf_home`. **By default it is an `emptyDir`** — scoped to the benchmark pod, so the cache is reclaimed when the pod exits and can never accumulate on the node's disk.
+
+A cluster with fast shared storage can keep a warm, cross-run cache by overriding the *volume source* (the mount path is unchanged either way — only cross-run persistence differs):
+
+- **Per-cluster (recommended):** set a `{GPU}_HF_CACHE_VOLUME` env var on the Buildkite agent to a JSON volume source (everything except the `name`). This is per-cluster because storage backends differ per cluster — the same idiom as `{GPU}_QUEUE`. Example:
+
+  ```
+  MI300X_HF_CACHE_VOLUME='{"persistentVolumeClaim":{"claimName":"buildkite-hf-cache"}}'
+  ```
+
+- **Per-profile:** set `hf_cache_volume:` in the profile in `lib/gpu_profiles.yaml` (env override wins over this).
+
+Do **not** set an `hf_home` under a node path like `/mnt/shared` unless that path is a real mount on every node in the queue — with the default `emptyDir` that only changes the in-pod path, but if you also point the volume at a `hostPath`, an unmounted path lands the cache on the node root disk with no reclamation.
+
+Run the generator's tests with `python3 .buildkite/test_generate_pipeline.py` (stdlib + pyyaml only; no GPU needed).
 
 ### Trigger a Buildkite build
 

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -20,11 +20,16 @@ MI300X:
   image_repo: vllm/vllm-openai-rocm
   server_runtime: native
   k8s_plugin: amd
-  hf_home: /mnt/shared/hf-models
+  # HF cache lives in the container default and is backed by an emptyDir volume
+  # (reclaimed when the pod exits). A cluster with fast shared storage can point
+  # this at a PVC/hostPath via the MI300X_HF_CACHE_VOLUME override; do NOT set an
+  # hf_home under /mnt/shared unless that path is a real mount on the node, or the
+  # cache lands on the root disk and is never reclaimed.
 
 MI355X:
   queue: mi355_perf_eval
   image_repo: vllm/vllm-openai-rocm
   server_runtime: native
   k8s_plugin: amd
-  hf_home: /mnt/shared/hf-models
+  # See MI300X — HF cache defaults to an emptyDir-backed container path; override
+  # the volume source per-cluster with MI355X_HF_CACHE_VOLUME.


### PR DESCRIPTION
## Problem

The AMD k8s plugin (`amd_k8s_plugin` in `.buildkite/generate_pipeline.py`) hardcodes the HuggingFace cache as a `hostPath` volume at the profile's `hf_home` (`/mnt/shared/hf-models` for the `MI300X`/`MI355X` profiles), with `type: DirectoryOrCreate`.

On any node where that path is **not** a real mount, `DirectoryOrCreate` silently creates it on the node's **root** partition. Because the benchmark pod is ephemeral and nothing reclaims the directory afterward, every run leaves a multi-hundred-GB model cache behind on the node root disk. These accumulate run over run until the disk fills — which we observed as nodes crossing into `DiskPressure` and evicting pods, with several hundred GB to multiple TB of orphaned model weights per node.

The current design exposes only `hf_home` (the *path*) as configurable — the volume *source* is fixed as a root-writable `hostPath`, so an operator cannot redirect the cache to persistent storage or make it ephemeral without editing this file.

## Change

Make the HF-cache volume **source** injectable, and default it to a safe, ephemeral `emptyDir`:

- New `hf_cache_volume(gpu, profile)` resolves the volume source in priority order:
  1. a `{GPU}_HF_CACHE_VOLUME` env var — JSON volume source (everything except `name`), settable per-agent. Same override idiom as the existing `{GPU}_QUEUE`.
  2. the profile's `hf_cache_volume` field in `lib/gpu_profiles.yaml`.
  3. otherwise `emptyDir: {}`.
- `amd_k8s_plugin` uses it in place of the hardcoded `hostPath`. The container mount path and `HF_HOME` are unchanged — **only cross-run persistence differs**.
- Dropped the `hf_home: /mnt/shared/...` line from the `MI300X`/`MI355X` profiles so the default no longer assumes a node mount. `hf_home` falls back to the in-container `/root/.cache/huggingface`, and the `emptyDir` backs it.

An operator with fast shared storage opts into a warm, cross-run cache by pointing the override at a PVC (or a real `hostPath` mount) — e.g.:

```
MI300X_HF_CACHE_VOLUME='{"persistentVolumeClaim":{"claimName":"hf-cache-pvc"}}'
```

## Scope / safety

- **Only `amd_k8s_plugin` changes.** The `nvidia` (B200) plugin and the H200 docker path are untouched.
- The new default (`emptyDir`) can never fill a node root disk: the cache is scoped to the pod and reclaimed on exit, and it counts against the pod's ephemeral-storage limit, so a runaway download evicts just that pod rather than wedging the node. The tradeoff is that a cluster with no override re-downloads weights each run; set the override to keep a warm cache.

## Tests

Adds `.buildkite/test_generate_pipeline.py` — stdlib + pyyaml only, no GPU/network:

```
python3 .buildkite/test_generate_pipeline.py
```

Covers: emptyDir default (never a hostPath), mount/`HF_HOME` agreement, profile-field override, env override precedence, per-GPU scoping of the env override, and a guard that the shipped AMD profiles never reintroduce a root-disk `hf_home`.

README updated with an "HF cache volume" section.

---

This PR was authored with assistance from Claude Code (AI-assisted).