### PR TITLE
Add xpu case

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -273,9 +273,10 @@ def make_step(path, data, profiles):
         setup_commands = [setup_command("'lm-eval[api]' pyyaml bfcl-eval soundfile")]
     else:
         setup_commands = FULL_SETUP_COMMANDS
+    agents = {"queue": queue, **(profile.get("agent_tags") or {})}
     step = {
         "label": f"{emoji} {name}",
-        "agents": {"queue": queue},
+        "agents": agents,
         "timeout_in_minutes": timeout,
         "commands": setup_commands + [RUN_TEMPLATE.format(path=path)],
         "artifact_paths": ["results/**/*"],

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -33,3 +33,13 @@ MI355X:
   k8s_plugin: amd
   # See MI300X — HF cache defaults to an emptyDir-backed container path; override
   # the volume source per-cluster with MI355X_HF_CACHE_VOLUME.
+
+XPU:
+  queue: intel-gpu
+  agent_tags:
+    label: performance
+    gpu: 1+
+    mem: 32+
+  image_repo: vllm/vllm-openai-xpu
+  server_runtime: xpu_docker
+  hf_home: /mnt/data2

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -42,4 +42,4 @@ XPU:
     mem: 32+
   image_repo: vllm/vllm-openai-xpu
   server_runtime: xpu_docker
-  hf_home: /mnt/data2
+  hf_home: /data/huggingface

--- a/lib/server.sh
+++ b/lib/server.sh
@@ -38,6 +38,24 @@ start_server() {
   local docker_args=(--gpus all --ipc=host --ulimit nofile=65536:65536
                      -e VLLM_ENGINE_READY_TIMEOUT_S=3600
                      -p "${port}:${port}")
+  local container_command=("$image" "$model" --port "$port" $serve_args)
+  if [[ "$runtime" == "xpu_docker" ]]; then
+    docker_args=(
+      --device /dev/dri:/dev/dri
+      --net=host
+      --ipc=host
+      --privileged
+      --ulimit nofile=65536:65536
+      -e VLLM_ENGINE_READY_TIMEOUT_S=3600
+    )
+    [[ -d /dev/dri/by-path ]] && docker_args+=(-v /dev/dri/by-path:/dev/dri/by-path)
+    [[ -n "${ZE_AFFINITY_MASK:-}" ]] && docker_args+=(-e "ZE_AFFINITY_MASK=${ZE_AFFINITY_MASK}")
+    [[ -n "${HF_TOKEN:-}" ]] && docker_args+=(-e "HF_TOKEN=${HF_TOKEN}")
+    local bash_serve_cmd
+    printf -v bash_serve_cmd 'source /root/.bashrc >/dev/null 2>&1; exec vllm serve %q --port %q %s' \
+      "$model" "$port" "$serve_args"
+    container_command=(--entrypoint /bin/bash "$image" -ic "$bash_serve_cmd")
+  fi
   local hf_home=""
   while IFS= read -r kv; do
     [[ -z "$kv" ]] && continue
@@ -52,8 +70,7 @@ start_server() {
   # vllm/vllm-openai's entrypoint takes the model as the first positional
   # arg; do not prepend `vllm` or `serve`.
   docker run -d --rm --name "$container" "${docker_args[@]}" \
-    "$image" \
-    "$model" --port "$port" $serve_args
+    "${container_command[@]}"
 
   # Install pytest to avoid cupy.testing import failure during torch.compile
   docker exec "$container" pip install -q pytest 2>/dev/null || true

--- a/workloads/gpt_oss_120b_B70.yaml
+++ b/workloads/gpt_oss_120b_B70.yaml
@@ -1,0 +1,46 @@
+# GPT-OSS 120B on XPU (8xXPU, TP=4)
+# Tracking perf regression: https://github.com/vllm-project/vllm/issues/40838
+name: gpt_oss_120b-xpu
+gpu: XPU
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: openai/gpt-oss-120b
+  serve_args: >-
+    --device xpu
+    --tensor-parallel-size 4
+    --max-model-len 32768
+    --max-num-seqs 512
+    --tool-call-parser openai
+    --enable-auto-tool-choice
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 4k-in-1k-out-conc-32
+      backend: openai
+      dataset: random
+      input_len: 4096
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 32

--- a/workloads/gpt_oss_120b_B70.yaml
+++ b/workloads/gpt_oss_120b_B70.yaml
@@ -2,16 +2,18 @@
 # Tracking perf regression: https://github.com/vllm-project/vllm/issues/40838
 name: gpt_oss_120b-xpu
 gpu: XPU
-num_gpus: 8
+num_gpus: 4
 nightly: true
 
 vllm:
   model: openai/gpt-oss-120b
   serve_args: >-
-    --device xpu
     --tensor-parallel-size 4
     --max-model-len 32768
     --max-num-seqs 512
+    --enforce-eager
+    --trust-remote-code
+    --no-enable-prefix-caching
     --tool-call-parser openai
     --enable-auto-tool-choice
 
@@ -42,5 +44,5 @@ vllm_bench:
       dataset: random
       input_len: 4096
       output_len: 1024
-      num_prompts: 512
+      num_prompts: 128
       max_concurrency: 32


### PR DESCRIPTION
## Summary

This PR ports the recent XPU-related perf-eval changes from `perf-eval` into `wenjun_perf-eval`.

The update includes:
- adding XPU workload support for `gpt_oss_120b`
- extending server startup logic to support the `xpu_docker` runtime
- updating GPU profiles with the XPU profile and matching cache path changes
- propagating agent tags in Buildkite pipeline generation

## Changes

### `.buildkite/generate_pipeline.py`
- pass through `agent_tags` from GPU profiles into Buildkite step `agents`
- align k8s plugin handling with the source repo changes

### `lib/gpu_profiles.yaml`
- add the `XPU` profile
- configure XPU queue, agent tags, image repo, runtime, and `HF_HOME`
- align `MI300X` and `MI355X` `hf_home` values with the source repo

### `lib/server.sh`
- add `xpu_docker` runtime handling
- support XPU container startup with `/dev/dri`, host networking, and optional `ZE_AFFINITY_MASK`
- pass through `HF_TOKEN` when present
- update health check to bypass proxy for localhost

### `workloads/gpt_oss_120b_xpu.yaml`
- add the XPU workload definition for `openai/gpt-oss-120b`
- use TP=4 and the current benchmark concurrency settings from the source repo

## Motivation

These changes bring `wenjun_perf-eval` in sync with the working XPU-related updates already made in `perf-eval`, so the same workload and runtime flow can be used in this repo.

## Validation
1. workload ： PASS
2. gsm8k: 
`    "gsm8k": {
      "name": "gsm8k",
      "alias": "gsm8k",
      "sample_len": 1319,
      "exact_match,strict-match": 0.5936315390447309,
      "exact_match_stderr,strict-match": 0.013528846685413239,
      "exact_match,flexible-extract": 0.844579226686884,
      "exact_match_stderr,flexible-extract": 0.009979689409499152
    }`
 3. bfcl:
 `Rank,Overall Acc,Model,Model Link,Total Cost ($),Latency Mean (s),Latency Standard Deviation (s),Latency 95th Percentile (s),Non-Live AST Acc,Non-Live Simple AST,Non-Live Multiple AST,Non-Live Parallel AST,Non-Live Parallel Multiple AST,Live Acc,Live Simple AST,Live Multiple AST,Live Parallel AST,Live Parallel Multiple AST,Multi Turn Acc,Multi Turn Base,Multi Turn Miss Func,Multi Turn Miss Param,Multi Turn Long Context,Web Search Acc,Web Search Base,Web Search No Snippet,Memory Acc,Memory KV,Memory Vector,Memory Recursive Summarization,Relevance Detection,Irrelevance Detection,Format Sensitivity Max Delta,Format Sensitivity Standard Deviation,Organization,License
1,19.29%,openai/gpt-oss-120b (FC) (vLLM),https://huggingface.co/openai/gpt-oss-120b,2.81,4.68,9.13,11.42,N/A,N/A,87.50%,N/A,N/A,0.00%,N/A,N/A,N/A,N/A,54.62%,64.00%,54.00%,52.00%,48.50%,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,,apache-2.0`
