### PR TITLE
Add Kimi-K2-Thinking NVFP4/INT4 gsm8k accuracy coverage (4xB200)

### DIFF
--- a/workloads/kimi_k2_thinking_int4_b200.yaml
+++ b/workloads/kimi_k2_thinking_int4_b200.yaml
@@ -1,0 +1,27 @@
+# Kimi-K2-Thinking INT4 (compressed-tensors) on B200 (4xB200, TP=4 + EP) -- accuracy-only (gsm8k)
+# Reference gsm8k (vLLM CI gsm8k harness, 5-shot, 1319 questions): 0.914
+name: kimi_k2_thinking_int4-b200
+gpu: B200
+num_gpus: 4
+nightly: true
+
+vllm:
+  model: moonshotai/Kimi-K2-Thinking
+  serve_args: >-
+    --tensor-parallel-size 4
+    --enable-expert-parallel
+    --enforce-eager
+    --max-model-len 4096
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 4096
+        max_gen_toks: 512

--- a/workloads/kimi_k2_thinking_nvfp4_b200.yaml
+++ b/workloads/kimi_k2_thinking_nvfp4_b200.yaml
@@ -1,0 +1,27 @@
+# Kimi-K2-Thinking NVFP4 on B200 (4xB200, TP=4 + EP) -- accuracy-only (gsm8k)
+# Reference gsm8k (vLLM CI gsm8k harness, 5-shot, 1319 questions): 0.921
+name: kimi_k2_thinking_nvfp4-b200
+gpu: B200
+num_gpus: 4
+nightly: true
+
+vllm:
+  model: nvidia/Kimi-K2-Thinking-NVFP4
+  serve_args: >-
+    --tensor-parallel-size 4
+    --enable-expert-parallel
+    --enforce-eager
+    --max-model-len 4096
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 4096
+        max_gen_toks: 512


### PR DESCRIPTION
Adds Kimi-K2-Thinking accuracy recipes on 4xB200 (TP=4 + EP) to the nightly, extending Blackwell large-MoE coverage so quantized correctness regressions surface in nightly instead of downstream.

Reference gsm8k (vLLM CI gsm8k harness, 5-shot / 1319q):
- Kimi-K2-Thinking NVFP4: 0.921
- Kimi-K2-Thinking INT4: 0.914

Accuracy-only (lm_eval gsm8k, completions path). Validated locally (parse_workload + generate_pipeline); B200 nightly run to follow.

AI-assisted (Claude Code).