### PR TITLE
Add Kimi K2.5 B200 workload

### DIFF
--- a/workloads/kimi_k2_5_b200.yaml
+++ b/workloads/kimi_k2_5_b200.yaml
@@ -2,7 +2,7 @@
 # Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K2.5
 name: kimi_k2_5-b200
 gpu: B200
-num_gpus: 8
+num_gpus: 4
 nightly: true
 
 vllm:
@@ -10,7 +10,7 @@ vllm:
   env:
     VLLM_USE_FLASHINFER_MOE_FP4: 1
   serve_args: >-
-    --tensor-parallel-size 8
+    --tensor-parallel-size 4
     --kv-cache-dtype fp8
     --mm-encoder-tp-mode data
     --tool-call-parser kimi_k2

--- a/workloads/kimi_k2_5_b200.yaml
+++ b/workloads/kimi_k2_5_b200.yaml
@@ -12,7 +12,6 @@ vllm:
   serve_args: >-
     --tensor-parallel-size 8
     --kv-cache-dtype fp8
-    --attention-config.use_trtllm_ragged_deepseek_prefill=True
     --mm-encoder-tp-mode data
     --tool-call-parser kimi_k2
     --reasoning-parser kimi_k2

--- a/workloads/kimi_k2_5_b200.yaml
+++ b/workloads/kimi_k2_5_b200.yaml
@@ -1,0 +1,55 @@
+# Kimi-K2.5 NVFP4 on B200
+# Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K2.5
+name: kimi_k2_5-b200
+gpu: B200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: nvidia/Kimi-K2.5-NVFP4
+  env:
+    VLLM_USE_FLASHINFER_MOE_FP4: 1
+  serve_args: >-
+    --tensor-parallel-size 8
+    --kv-cache-dtype fp8
+    --attention-config.use_trtllm_ragged_deepseek_prefill=True
+    --mm-encoder-tp-mode data
+    --tool-call-parser kimi_k2
+    --reasoning-parser kimi_k2
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --speculative-config {"model":"lightseekorg/kimi-k2.5-eagle3-mla","method":"eagle3","num_speculative_tokens":3}
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 16
+  max_test_cases:
+    multi_turn: 240
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary
- add a Kimi K2.5 NVFP4 workload for four B200 GPUs
- follow the official vLLM Blackwell recipe with FlashInfer FP4, FP8 KV cache, and Eagle3 speculative decoding
- retain the existing Kimi GSM8K, BFCL, and random serving benchmark coverage

Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K2.5

## Local validation
- parser smoke test with a stubbed `lm_eval` registry
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `python3 .buildkite/test_generate_pipeline.py` (6/6 passed)
- explicit `WORKLOADS=workloads/kimi_k2_5_b200.yaml` pipeline generation
- `git diff --check`

## GPU validation
- [Buildkite #311](https://buildkite.com/vllm/perf-eval/builds/311): exposed an unavailable optional attention-config field in the pinned nightly
- [Buildkite #315](https://buildkite.com/vllm/perf-eval/builds/315): infrastructure-only failure; the pod remained Pending for 15 minutes and the workload never started
- [Buildkite #316](https://buildkite.com/vllm/perf-eval/builds/316): passed in 46m56s on 4x B200; server startup, the 512-request 8K/1K serving benchmark, GSM8K, and all five BFCL categories completed successfully