### PR TITLE
Add GPT-OSS 120B B200 workload

### DIFF
--- a/workloads/gpt_oss_120b_b200.yaml
+++ b/workloads/gpt_oss_120b_b200.yaml
@@ -1,0 +1,52 @@
+# GPT-OSS 120B on B200 (single B200, TP=1)
+# Recipe: https://recipes.vllm.ai/openai/gpt-oss-120b
+name: gpt_oss_120b-b200
+gpu: B200
+num_gpus: 1
+nightly: true
+
+vllm:
+  model: openai/gpt-oss-120b
+  env:
+    VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: 1
+  serve_args: >-
+    --tensor-parallel-size 1
+    --kv-cache-dtype fp8
+    --no-enable-prefix-caching
+    --max-cudagraph-capture-size 2048
+    --max-num-batched-tokens 8192
+    --stream-interval 20
+    --max-model-len 32768
+    --max-num-seqs 512
+    --tool-call-parser openai
+    --enable-auto-tool-choice
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary
- add a single-B200 GPT-OSS 120B workload
- follow the official vLLM Blackwell recipe with FlashInfer MXFP4/MXFP8 MoE, FP8 KV cache, and the recommended CUDA graph/batching settings
- retain the existing GPT-OSS GSM8K, BFCL, and random serving benchmark coverage

Recipe: https://recipes.vllm.ai/openai/gpt-oss-120b

## Local validation
- parser smoke test with a stubbed `lm_eval` registry
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `python3 .buildkite/test_generate_pipeline.py` (6/6 passed)
- explicit `WORKLOADS=gpt_oss_120b_b200` pipeline generation
- `git diff --check`

## GPU validation
- [Buildkite #312](https://buildkite.com/vllm/perf-eval/builds/312): passed end-to-end in 35m28s on one B200
- vLLM `0.23.1rc1.dev1327+gf25953cc5` loaded the MXFP4 checkpoint with the FlashInfer expert backend and exposed about 3.53M KV-cache tokens
- the 8K-input/1K-output concurrency-128 serving benchmark completed successfully
- GSM8K completed all 1,319 requests (flexible exact match 0.8469; strict exact match 0.5951)
- all configured BFCL categories completed