### PR TITLE
Add DeepSeek V4 Pro B200 workload

### DIFF
--- a/workloads/deepseek_v4_pro_b200.yaml
+++ b/workloads/deepseek_v4_pro_b200.yaml
@@ -8,6 +8,7 @@ nightly: true
 vllm:
   model: nvidia/DeepSeek-V4-Pro-NVFP4
   env:
+    CUDA_HOME: /usr/local/cuda
     TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
   serve_args: >-
     --tensor-parallel-size 8

--- a/workloads/deepseek_v4_pro_b200.yaml
+++ b/workloads/deepseek_v4_pro_b200.yaml
@@ -1,4 +1,4 @@
-# DeepSeek-V4-Pro NVFP4 on B200 (8xB200, TP=8 + EP)
+# DeepSeek-V4-Pro NVFP4 on B200 (8xB200, DP=8 + EP)
 # Recipe: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Pro
 name: deepseek_v4_pro-b200
 gpu: B200
@@ -11,7 +11,7 @@ vllm:
     CUDA_HOME: /usr/local/cuda
     TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
   serve_args: >-
-    --tensor-parallel-size 8
+    --data-parallel-size 8
     --enable-expert-parallel
     --max-model-len 32768
     --max-num-seqs 512

--- a/workloads/deepseek_v4_pro_b200.yaml
+++ b/workloads/deepseek_v4_pro_b200.yaml
@@ -1,0 +1,61 @@
+# DeepSeek-V4-Pro NVFP4 on B200 (8xB200, TP=8 + EP)
+# Recipe: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Pro
+name: deepseek_v4_pro-b200
+gpu: B200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: nvidia/DeepSeek-V4-Pro-NVFP4
+  env:
+    TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+  serve_args: >-
+    --tensor-parallel-size 8
+    --enable-expert-parallel
+    --max-model-len 32768
+    --max-num-seqs 512
+    --max-num-batched-tokens 512
+    --kv-cache-dtype fp8
+    --block-size 256
+    --attention_config.use_fp4_indexer_cache=True
+    --tokenizer-mode deepseek_v4
+    --gpu-memory-utilization 0.95
+    --tool-call-parser deepseek_v4
+    --reasoning-parser deepseek_v4
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --compilation-config {"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 16
+  max_test_cases:
+    multi_turn: 240
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128

--- a/workloads/deepseek_v4_pro_b200.yaml
+++ b/workloads/deepseek_v4_pro_b200.yaml
@@ -1,4 +1,4 @@
-# DeepSeek-V4-Pro NVFP4 on B200 (8xB200, DP=8 + EP)
+# DeepSeek-V4-Pro NVFP4 on B200 (8xB200, TP=8 + EP)
 # Recipe: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Pro
 name: deepseek_v4_pro-b200
 gpu: B200
@@ -11,7 +11,7 @@ vllm:
     CUDA_HOME: /usr/local/cuda
     TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
   serve_args: >-
-    --data-parallel-size 8
+    --tensor-parallel-size 8
     --enable-expert-parallel
     --max-model-len 32768
     --max-num-seqs 512
@@ -25,6 +25,7 @@ vllm:
     --reasoning-parser deepseek_v4
     --enable-auto-tool-choice
     --trust-remote-code
+    --kernel-config {"enable_jit_warmup":false}
     --compilation-config {"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}
 
 lm_eval:


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary
- add an 8x B200 DeepSeek V4 Pro NVFP4 workload
- follow the official Blackwell TP8 + expert-parallel topology with FP8 KV cache, FP4 indexer cache, and full/piecewise CUDA graphs
- retain the existing DeepSeek GSM8K, BFCL, and random serving benchmark coverage
- pin TileLang to the image's system CUDA toolkit so its JIT compiler and headers stay version-matched
- skip the pinned image's generic FA4/MLA JIT warmup, which is incompatible with DeepSeek V4's CSA/HCA configuration; model-specific warmup and FlashInfer autotuning remain enabled

Recipe: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Pro

## Local validation
- parser smoke test with a stubbed `lm_eval` registry
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `python3 .buildkite/test_generate_pipeline.py` (6/6 passed)
- explicit `WORKLOADS=deepseek_v4_pro_b200` pipeline generation
- `git diff --check`

## GPU validation
- [Buildkite #313](https://buildkite.com/vllm/perf-eval/builds/313): acquired 8x B200, downloaded and loaded the 64-shard NVFP4 checkpoint, then failed when TileLang selected the pip CUDA compiler package and hit incompatible CUDA compiler/toolkit headers while compiling `mhc_pre_big_fuse_broadcast_with_norm_tilelang`
- commit `7e9eb94` sets `CUDA_HOME=/usr/local/cuda`, selecting the CUDA 13.0 compiler and headers installed together in the vLLM image
- [Buildkite #318](https://buildkite.com/vllm/perf-eval/builds/318): all TileLang MHC kernels compiled successfully, validating the CUDA fix; startup then failed in generic `fa4_cutedsl_warmup()` because DeepSeek V4 intentionally has no legacy MLA `qk_nope_head_dim` or `v_head_dim`
- [Buildkite #320](https://buildkite.com/vllm/perf-eval/builds/320): DP8 + EP reproduced the identical generic warmup failure, ruling out parallel topology as the cause
- commit `eb441cc` restores the recipe-default TP8 + EP topology and sets `kernel_config.enable_jit_warmup=false`, skipping only the incompatible generic FA4/MLA warmup
- [Buildkite #321](https://buildkite.com/vllm/perf-eval/builds/321): passed in 34m00s on 8x B200; model-specific warmup, FlashInfer autotuning, CUDA graph capture, server health, the 512-request serving benchmark, GSM8K, and all five BFCL categories completed successfully