### PR TITLE
Add Devstral-Small-2-24B gsm8k accuracy coverage (1xB200)

### DIFF
--- a/workloads/devstral_small_2_24b_b200.yaml
+++ b/workloads/devstral_small_2_24b_b200.yaml
@@ -1,0 +1,29 @@
+# Devstral-Small-2-24B-Instruct-2512 (FP8) on B200 (1xB200, TP=1) -- accuracy-only (gsm8k)
+# Reference gsm8k (vLLM CI gsm8k harness, 5-shot, 1319 questions): 0.834
+# --limit-mm-per-prompt {"image":0} disables the vision path (gsm8k is text-only)
+# and avoids the multimodal image-fetch init on this Mistral vision model.
+name: devstral_small_2_24b-b200
+gpu: B200
+num_gpus: 1
+nightly: true
+
+vllm:
+  model: mistralai/Devstral-Small-2-24B-Instruct-2512
+  serve_args: >-
+    --tensor-parallel-size 1
+    --enforce-eager
+    --max-model-len 4096
+    --limit-mm-per-prompt {"image":0}
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 4096
+        max_gen_toks: 512


### PR DESCRIPTION
## Summary
- Add nightly gsm8k accuracy recipe for `mistralai/Devstral-Small-2-24B-Instruct-2512` on 1xB200 (TP=1)
- Covers the Mistral/Pixtral arch (nothing else in the nightly does); 250K dl/mo, 24B, cheap; vision path disabled for text-only gsm8k
- Reference gsm8k (vLLM CI gsm8k harness, 5-shot / 1319q): 0.834

AI-assisted (Claude Code).