### PR TITLE
Add Qwen3.6-35B-A3B NVFP4 gsm8k accuracy coverage (1xB200)

### DIFF
--- a/workloads/qwen3_6_35b_a3b_nvfp4_b200.yaml
+++ b/workloads/qwen3_6_35b_a3b_nvfp4_b200.yaml
@@ -1,0 +1,27 @@
+# Qwen3.6-35B-A3B NVFP4 on B200 (1xB200, TP=1) -- accuracy-only (gsm8k)
+# 256-expert MoE, ~3B active (qwen3_5_moe arch), NVFP4 (modelopt mixed-precision).
+name: qwen3_6_35b_a3b_nvfp4-b200
+gpu: B200
+num_gpus: 1
+nightly: true
+
+vllm:
+  model: nvidia/Qwen3.6-35B-A3B-NVFP4
+  serve_args: >-
+    --tensor-parallel-size 1
+    --enforce-eager
+    --max-model-len 4096
+    --trust-remote-code
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 4096
+        max_gen_toks: 512


### PR DESCRIPTION
## Summary
- Add nightly gsm8k accuracy recipe for `nvidia/Qwen3.6-35B-A3B-NVFP4` on 1xB200 (TP=1)
- Most-downloaded NVFP4 checkpoint on HF (9.3M dl/mo), currently uncovered; cheap (256-expert MoE, ~3B active)

## Test plan
- [ ] B200 accuracy verification (serve + gsm8k baseline); serve_args finalized after

AI-assisted (Claude Code).