### PR TITLE
Add GLM-5.2 standalone B300 SGLang benchmark

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -10,6 +10,7 @@ Always emits one GPU-profiled step per selected workload. Selection rules:
 Override env vars are propagated to each step:
   VLLM_IMAGE   full docker image URI; overrides workload's vllm.image
   VLLM_COMMIT  commit SHA → vllm/vllm-openai:nightly-<sha> (Docker Hub)
+  SGLANG_IMAGE full docker image URI; overrides workload's sglang.image
   BENCH_ONLY   when truthy, run vllm bench configs and skip lm_eval tasks
 
 Workloads can also set ``bench_only: true`` to apply BENCH_ONLY to that step
@@ -53,6 +54,7 @@ RUN_TEMPLATE = (
 DEFAULT_TIMEOUT = 120
 PROFILES_PATH = os.path.join(os.path.dirname(__file__), "..", "lib", "gpu_profiles.yaml")
 DEFAULT_IMAGE_REPO = "vllm/vllm-openai"
+DEFAULT_SGLANG_IMAGE = "lmsysorg/sglang:latest"
 
 GPU_EMOJI = {
     "H200": ":h200:",
@@ -90,7 +92,18 @@ def commit_from_image(image):
     return m.group(1) if m else ""
 
 
+def server_config(data):
+    if data.get("sglang"):
+        return "sglang", data.get("sglang") or {}
+    return "vllm", data.get("vllm") or {}
+
+
 def resolved_image(data, profile):
+    engine, server = server_config(data)
+    if engine == "sglang":
+        override_image = (os.environ.get("SGLANG_IMAGE") or "").strip()
+        return override_image or server.get("image", DEFAULT_SGLANG_IMAGE)
+
     vllm = data.get("vllm") or {}
     override_image = (os.environ.get("VLLM_IMAGE") or "").strip()
     override_commit = (os.environ.get("VLLM_COMMIT") or "").strip()
@@ -102,7 +115,7 @@ def resolved_image(data, profile):
     commit = override_commit or commit_from_image(override_image)
     if commit:
         return f"{repo}:nightly-{commit}"
-    return vllm.get("image", f"{repo}:nightly")
+    return server.get("image", f"{repo}:nightly")
 
 
 def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
@@ -267,7 +280,8 @@ def make_step(path, data, profiles):
         data.get("bench_only")
     )
     has_bfcl = bool(data.get("bfcl"))
-    if bench_only:
+    has_sglang_bench = bool(data.get("sglang_bench"))
+    if bench_only or has_sglang_bench:
         setup_commands = BENCH_ONLY_SETUP_COMMANDS
     elif has_bfcl:
         setup_commands = [setup_command("'lm-eval[api]' pyyaml bfcl-eval soundfile")]
@@ -297,6 +311,8 @@ def make_step(path, data, profiles):
         for k in ("VLLM_IMAGE", "VLLM_COMMIT", "BENCH_ONLY")
         if os.environ.get(k)
     }
+    if os.environ.get("SGLANG_IMAGE"):
+        step_env["SGLANG_IMAGE"] = os.environ["SGLANG_IMAGE"]
     if bench_only and "BENCH_ONLY" not in step_env:
         step_env["BENCH_ONLY"] = "1"
     if step_env:

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -129,6 +129,7 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
             "podSpecPatch": {
                 "runtimeClassName": "nvidia",
                 "hostNetwork": True,
+                "hostIPC": True,
                 "dnsPolicy": "ClusterFirstWithHostNet",
                 "imagePullSecrets": [
                     {"name": "k8s-ecr-login-renew-docker-secret"},
@@ -139,12 +140,14 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                         "image": image,
                         "resources": {"limits": {"nvidia.com/gpu": num_gpus}},
                         "securityContext": {
+                            "privileged": True,
                             "capabilities": {
-                                "add": ["IPC_LOCK", "SYS_RESOURCE"],
+                                "add": ["IPC_LOCK", "SYS_RESOURCE", "SYS_ADMIN"],
                             },
                         },
                         "volumeMounts": [
                             {"name": "devshm", "mountPath": "/dev/shm"},
+                            {"name": "infiniband", "mountPath": "/dev/infiniband"},
                             {"name": "raid", "mountPath": "/raid"},
                             {"name": "shared", "mountPath": "/mnt/shared"},
                         ],
@@ -166,6 +169,10 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                 ],
                 "volumes": [
                     {"name": "devshm", "emptyDir": {"medium": "Memory"}},
+                    {
+                        "name": "infiniband",
+                        "hostPath": {"path": "/dev/infiniband", "type": "Directory"},
+                    },
                     {
                         "name": "raid",
                         "hostPath": {"path": "/raid", "type": "DirectoryOrCreate"},

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -284,11 +284,6 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
             "gpus": "all",
             "network": "host",
             "ipc": "host",
-            **(
-                {"add-caps": profile["add_caps"]}
-                if profile.get("add_caps")
-                else {}
-            ),
             "ulimits": ["memlock=-1", "stack=67108864"],
             "environment": [
                 "VLLM_USAGE_SOURCE=ci-test",

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -291,6 +291,7 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
                 f"HF_HOME={hf_home}",
                 "HOME=/raid/buildkite/home",
                 "XDG_CACHE_HOME=/raid/buildkite/cache",
+                "FLASHINFER_CUBIN_DIR=/raid/buildkite/flashinfer-cubins",
                 "HF_TOKEN",
             ],
             "volumes": [

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -145,7 +145,6 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                 },
                 "volumeMounts": [
                     {"name": "devshm", "mountPath": "/dev/shm"},
-                    {"name": "infiniband", "mountPath": "/dev/infiniband"},
                     {"name": "raid", "mountPath": "/raid"},
                     {"name": "shared", "mountPath": "/mnt/shared"},
                 ],
@@ -167,10 +166,6 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
         ],
         "volumes": [
             {"name": "devshm", "emptyDir": {"medium": "Memory"}},
-            {
-                "name": "infiniband",
-                "hostPath": {"path": "/dev/infiniband", "type": "Directory"},
-            },
             {
                 "name": "raid",
                 "hostPath": {"path": "/raid", "type": "DirectoryOrCreate"},

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -291,12 +291,12 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
                 f"HF_HOME={hf_home}",
                 "HOME=/raid/buildkite/home",
                 "XDG_CACHE_HOME=/raid/buildkite/cache",
-                "FLASHINFER_CUBIN_DIR=/raid/buildkite/flashinfer-cubins",
                 "HF_TOKEN",
             ],
             "volumes": [
                 "/dev/shm:/dev/shm",
                 "/raid:/raid",
+                *(profile.get("extra_volumes") or []),
             ],
         },
     }

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -52,7 +52,10 @@ BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml")]
 NATIVE_BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml", system_site_packages=True)]
 
 RUN_TEMPLATE = (
-    'export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$HOME/.local/bin:$PATH"'
+    # Double-dollar escapes Buildkite pipeline-upload interpolation so the
+    # runtime container, not the upload agent, resolves its injected HF_HOME.
+    'export HF_HOME="$${{HF_HOME:-$(pwd)/.hf-cache}}"'
+    ' PATH="$(pwd)/.venv/bin:$HOME/.local/bin:$PATH"'
     " && ./lib/run.sh {path}"
 )
 
@@ -64,6 +67,7 @@ DEFAULT_SGLANG_IMAGE = "lmsysorg/sglang:latest"
 GPU_EMOJI = {
     "H200": ":h200:",
     "B200": ":b200:",
+    "B300": ":b300:",
     "A100": ":a100:",
     "MI355X": ":amd:",
     "MI300X": ":amd:",
@@ -263,6 +267,38 @@ K8S_PLUGINS = {
 }
 
 
+def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
+    """Run a native perf-eval step on a standalone NVIDIA Docker agent."""
+    profile = profile or {}
+    hf_home = profile.get("hf_home") or "/root/.cache/huggingface"
+    return {
+        "docker#v5.2.0": {
+            "image": image,
+            "always-pull": profile.get("always_pull", True),
+            "propagate-environment": True,
+            "gpus": "all",
+            "network": "host",
+            "ipc": "host",
+            "ulimits": ["memlock=-1", "stack=67108864"],
+            "environment": [
+                "VLLM_USAGE_SOURCE=ci-test",
+                "NCCL_CUMEM_HOST_ENABLE=0",
+                f"HF_HOME={hf_home}",
+                "HF_TOKEN",
+            ],
+            "volumes": [
+                "/dev/shm:/dev/shm",
+                "/raid:/raid",
+            ],
+        },
+    }
+
+
+DOCKER_PLUGINS = {
+    "nvidia": nvidia_docker_plugin,
+}
+
+
 def load_profiles():
     with open(PROFILES_PATH) as f:
         return yaml.safe_load(f)
@@ -324,15 +360,27 @@ def make_step(path, data, profiles):
         "artifact_paths": ["results/**/*"],
     }
     if native_runtime:
-        kind = profile.get("k8s_plugin")
-        if not kind:
+        k8s_kind = profile.get("k8s_plugin")
+        docker_kind = profile.get("docker_plugin")
+        if bool(k8s_kind) == bool(docker_kind):
             sys.exit(
-                f"{path}: profile {gpu!r} sets server_runtime: native but no"
-                f" k8s_plugin; set one explicitly (have {', '.join(K8S_PLUGINS)})"
+                f"{path}: profile {gpu!r} sets server_runtime: native; set exactly"
+                " one of k8s_plugin or docker_plugin"
             )
-        builder = K8S_PLUGINS.get(kind)
-        if builder is None:
-            sys.exit(f"{path}: unknown k8s_plugin {kind!r} (have {', '.join(K8S_PLUGINS)})")
+        if k8s_kind:
+            builder = K8S_PLUGINS.get(k8s_kind)
+            if builder is None:
+                sys.exit(
+                    f"{path}: unknown k8s_plugin {k8s_kind!r}"
+                    f" (have {', '.join(K8S_PLUGINS)})"
+                )
+        else:
+            builder = DOCKER_PLUGINS.get(docker_kind)
+            if builder is None:
+                sys.exit(
+                    f"{path}: unknown docker_plugin {docker_kind!r}"
+                    f" (have {', '.join(DOCKER_PLUGINS)})"
+                )
         image = ecr_pull_through(resolved_image(data, profile))
         step["plugins"] = [builder(image, data.get("num_gpus", 1), profile, gpu)]
     step_env = {

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -121,7 +121,7 @@ def resolved_image(data, profile):
 def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
     return {
         "kubernetes": {
-            "podSpec": {
+            "podSpecPatch": {
                 "runtimeClassName": "nvidia",
                 "hostNetwork": True,
                 "dnsPolicy": "ClusterFirstWithHostNet",
@@ -130,6 +130,7 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                 ],
                 "containers": [
                     {
+                        "name": "container-0",
                         "image": image,
                         "resources": {"limits": {"nvidia.com/gpu": num_gpus}},
                         "securityContext": {

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -26,9 +26,10 @@ import sys
 
 import yaml
 
-def setup_command(packages):
+def setup_command(packages, system_site_packages=False):
+    venv_args = "--system-site-packages .venv" if system_site_packages else ".venv"
     return (
-        "if python3 -m venv .venv; then\n"
+        f"if python3 -m venv {venv_args}; then\n"
         "  . .venv/bin/activate\n"
         "  (python -m ensurepip --upgrade --default-pip 2>/dev/null"
         " || curl -fsSL https://bootstrap.pypa.io/get-pip.py | python)\n"
@@ -43,8 +44,12 @@ def setup_command(packages):
 
 
 FULL_SETUP_COMMANDS = [setup_command("'lm-eval[api]' pyyaml")]
+NATIVE_FULL_SETUP_COMMANDS = [
+    setup_command("'lm-eval[api]' pyyaml", system_site_packages=True)
+]
 
 BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml")]
+NATIVE_BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml", system_site_packages=True)]
 
 RUN_TEMPLATE = (
     'export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$HOME/.local/bin:$PATH"'
@@ -282,10 +287,22 @@ def make_step(path, data, profiles):
     )
     has_bfcl = bool(data.get("bfcl"))
     has_sglang_bench = bool(data.get("sglang_bench"))
-    if bench_only or has_sglang_bench:
+    native_runtime = profile.get("server_runtime") == "native"
+    if (bench_only or has_sglang_bench) and native_runtime:
+        setup_commands = NATIVE_BENCH_ONLY_SETUP_COMMANDS
+    elif bench_only or has_sglang_bench:
         setup_commands = BENCH_ONLY_SETUP_COMMANDS
+    elif has_bfcl and native_runtime:
+        setup_commands = [
+            setup_command(
+                "'lm-eval[api]' pyyaml bfcl-eval soundfile",
+                system_site_packages=True,
+            )
+        ]
     elif has_bfcl:
         setup_commands = [setup_command("'lm-eval[api]' pyyaml bfcl-eval soundfile")]
+    elif native_runtime:
+        setup_commands = NATIVE_FULL_SETUP_COMMANDS
     else:
         setup_commands = FULL_SETUP_COMMANDS
     step = {
@@ -295,7 +312,7 @@ def make_step(path, data, profiles):
         "commands": setup_commands + [RUN_TEMPLATE.format(path=path)],
         "artifact_paths": ["results/**/*"],
     }
-    if profile.get("server_runtime") == "native":
+    if native_runtime:
         kind = profile.get("k8s_plugin")
         if not kind:
             sys.exit(

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -284,6 +284,11 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
             "gpus": "all",
             "network": "host",
             "ipc": "host",
+            **(
+                {"add-caps": profile["add_caps"]}
+                if profile.get("add_caps")
+                else {}
+            ),
             "ulimits": ["memlock=-1", "stack=67108864"],
             "environment": [
                 "VLLM_USAGE_SOURCE=ci-test",

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -183,7 +183,7 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
     }
     node_name = (os.environ.get("B200_NODE_NAME") or "").strip()
     if node_name:
-        pod_spec["nodeName"] = node_name
+        pod_spec["nodeSelector"] = {"kubernetes.io/hostname": node_name}
     return {
         "kubernetes": {
             "podSpecPatch": pod_spec,

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -124,65 +124,69 @@ def resolved_image(data, profile):
 
 
 def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
-    return {
-        "kubernetes": {
-            "podSpecPatch": {
-                "runtimeClassName": "nvidia",
-                "hostNetwork": True,
-                "hostIPC": True,
-                "dnsPolicy": "ClusterFirstWithHostNet",
-                "imagePullSecrets": [
-                    {"name": "k8s-ecr-login-renew-docker-secret"},
+    pod_spec = {
+        "runtimeClassName": "nvidia",
+        "hostNetwork": True,
+        "hostIPC": True,
+        "dnsPolicy": "ClusterFirstWithHostNet",
+        "imagePullSecrets": [
+            {"name": "k8s-ecr-login-renew-docker-secret"},
+        ],
+        "containers": [
+            {
+                "name": "container-0",
+                "image": image,
+                "resources": {"limits": {"nvidia.com/gpu": num_gpus}},
+                "securityContext": {
+                    "privileged": True,
+                    "capabilities": {
+                        "add": ["IPC_LOCK", "SYS_RESOURCE", "SYS_ADMIN"],
+                    },
+                },
+                "volumeMounts": [
+                    {"name": "devshm", "mountPath": "/dev/shm"},
+                    {"name": "infiniband", "mountPath": "/dev/infiniband"},
+                    {"name": "raid", "mountPath": "/raid"},
+                    {"name": "shared", "mountPath": "/mnt/shared"},
                 ],
-                "containers": [
+                "env": [
+                    {"name": "VLLM_USAGE_SOURCE", "value": "ci-test"},
+                    {"name": "NCCL_CUMEM_HOST_ENABLE", "value": "0"},
+                    {"name": "HF_HOME", "value": "/mnt/shared/hf_cache"},
                     {
-                        "name": "container-0",
-                        "image": image,
-                        "resources": {"limits": {"nvidia.com/gpu": num_gpus}},
-                        "securityContext": {
-                            "privileged": True,
-                            "capabilities": {
-                                "add": ["IPC_LOCK", "SYS_RESOURCE", "SYS_ADMIN"],
+                        "name": "HF_TOKEN",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "hf-token-secret",
+                                "key": "token",
                             },
                         },
-                        "volumeMounts": [
-                            {"name": "devshm", "mountPath": "/dev/shm"},
-                            {"name": "infiniband", "mountPath": "/dev/infiniband"},
-                            {"name": "raid", "mountPath": "/raid"},
-                            {"name": "shared", "mountPath": "/mnt/shared"},
-                        ],
-                        "env": [
-                            {"name": "VLLM_USAGE_SOURCE", "value": "ci-test"},
-                            {"name": "NCCL_CUMEM_HOST_ENABLE", "value": "0"},
-                            {"name": "HF_HOME", "value": "/mnt/shared/hf_cache"},
-                            {
-                                "name": "HF_TOKEN",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "name": "hf-token-secret",
-                                        "key": "token",
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                ],
-                "volumes": [
-                    {"name": "devshm", "emptyDir": {"medium": "Memory"}},
-                    {
-                        "name": "infiniband",
-                        "hostPath": {"path": "/dev/infiniband", "type": "Directory"},
-                    },
-                    {
-                        "name": "raid",
-                        "hostPath": {"path": "/raid", "type": "DirectoryOrCreate"},
-                    },
-                    {
-                        "name": "shared",
-                        "hostPath": {"path": "/mnt/shared", "type": "DirectoryOrCreate"},
                     },
                 ],
             },
+        ],
+        "volumes": [
+            {"name": "devshm", "emptyDir": {"medium": "Memory"}},
+            {
+                "name": "infiniband",
+                "hostPath": {"path": "/dev/infiniband", "type": "Directory"},
+            },
+            {
+                "name": "raid",
+                "hostPath": {"path": "/raid", "type": "DirectoryOrCreate"},
+            },
+            {
+                "name": "shared",
+                "hostPath": {"path": "/mnt/shared", "type": "DirectoryOrCreate"},
+            },
+        ],
+    }
+    node_name = (os.environ.get("B200_NODE_NAME") or "").strip()
+    if node_name:
+        pod_spec["nodeName"] = node_name
+    return {
+        "kubernetes": {
+            "podSpecPatch": pod_spec,
         },
     }
 

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -145,6 +145,7 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                 },
                 "volumeMounts": [
                     {"name": "devshm", "mountPath": "/dev/shm"},
+                    {"name": "infiniband", "mountPath": "/dev/infiniband"},
                     {"name": "raid", "mountPath": "/raid"},
                     {"name": "shared", "mountPath": "/mnt/shared"},
                 ],
@@ -166,6 +167,10 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
         ],
         "volumes": [
             {"name": "devshm", "emptyDir": {"medium": "Memory"}},
+            {
+                "name": "infiniband",
+                "hostPath": {"path": "/dev/infiniband", "type": "Directory"},
+            },
             {
                 "name": "raid",
                 "hostPath": {"path": "/raid", "type": "DirectoryOrCreate"},

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -276,6 +276,10 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
             "image": image,
             "always-pull": profile.get("always_pull", True),
             "propagate-environment": True,
+            # Framework images define serving entrypoints. Disable them so the
+            # Buildkite step command runs through a shell inside the container.
+            "entrypoint": "",
+            "shell": ["/bin/sh", "-e", "-c"],
             "gpus": "all",
             "network": "host",
             "ipc": "host",

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -280,6 +280,7 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
             # Buildkite step command runs through a shell inside the container.
             "entrypoint": "",
             "shell": ["/bin/sh", "-e", "-c"],
+            "propagate-uid-gid": True,
             "gpus": "all",
             "network": "host",
             "ipc": "host",
@@ -288,6 +289,8 @@ def nvidia_docker_plugin(image, num_gpus, profile=None, gpu=None):
                 "VLLM_USAGE_SOURCE=ci-test",
                 "NCCL_CUMEM_HOST_ENABLE=0",
                 f"HF_HOME={hf_home}",
+                "HOME=/raid/buildkite/home",
+                "XDG_CACHE_HOME=/raid/buildkite/cache",
                 "HF_TOKEN",
             ],
             "volumes": [

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -182,6 +182,8 @@ def test_b300_profile_uses_standalone_docker_plugin():
         "/raid/buildkite/flashinfer-cubins-sglang:"
         "/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins"
     ) in docker["volumes"]
+    assert "/etc/passwd:/etc/passwd:ro" in docker["volumes"]
+    assert "/etc/group:/etc/group:ro" in docker["volumes"]
 
 
 def test_run_command_preserves_injected_hf_home():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -225,7 +225,7 @@ def test_glm_b300_sglang_uses_matched_real_eagle_shape():
         "--dp 8",
         "--enable-dp-attention",
         "--moe-a2a-backend none",
-        "--moe-runner-backend deep_gemm",
+        "--moe-runner-backend triton",
         "--kv-cache-dtype fp8_e4m3",
         "--speculative-algorithm EAGLE",
         "--speculative-num-steps 1",

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -178,6 +178,7 @@ def test_b300_profile_uses_standalone_docker_plugin():
     assert "HF_HOME=/raid/buildkite/hf-cache" in docker["environment"]
     assert "HOME=/raid/buildkite/home" in docker["environment"]
     assert "XDG_CACHE_HOME=/raid/buildkite/cache" in docker["environment"]
+    assert "FLASHINFER_CUBIN_DIR=/raid/buildkite/flashinfer-cubins" in docker["environment"]
 
 
 def test_run_command_preserves_injected_hf_home():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -169,12 +169,15 @@ def test_b300_profile_uses_standalone_docker_plugin():
     assert profile["queue"] == "b300-8"
     assert docker["entrypoint"] == ""
     assert docker["shell"] == ["/bin/sh", "-e", "-c"]
+    assert docker["propagate-uid-gid"] is True
     assert docker["gpus"] == "all"
     assert docker["network"] == "host"
     assert docker["ipc"] == "host"
     assert "memlock=-1" in docker["ulimits"]
     assert "/raid:/raid" in docker["volumes"]
-    assert "HF_HOME=/raid/inf-simon/hf-cache" in docker["environment"]
+    assert "HF_HOME=/raid/buildkite/hf-cache" in docker["environment"]
+    assert "HOME=/raid/buildkite/home" in docker["environment"]
+    assert "XDG_CACHE_HOME=/raid/buildkite/cache" in docker["environment"]
 
 
 def test_run_command_preserves_injected_hf_home():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -42,6 +42,16 @@ def test_b200_uses_podspec_patch_to_override_agent_container():
     assert c["name"] == "container-0"
     assert c["image"] == "lmsysorg/sglang:latest"
     assert c["resources"]["limits"]["nvidia.com/gpu"] == 8
+    assert patch["hostIPC"] is True
+    assert c["securityContext"]["privileged"] is True
+    assert "SYS_ADMIN" in c["securityContext"]["capabilities"]["add"]
+    mounts = {m["name"]: m["mountPath"] for m in c["volumeMounts"]}
+    volumes = {v["name"]: v for v in patch["volumes"]}
+    assert mounts["infiniband"] == "/dev/infiniband"
+    assert volumes["infiniband"]["hostPath"] == {
+        "path": "/dev/infiniband",
+        "type": "Directory",
+    }
 
 
 def test_native_runtime_venv_keeps_image_packages_visible():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -178,7 +178,10 @@ def test_b300_profile_uses_standalone_docker_plugin():
     assert "HF_HOME=/raid/buildkite/hf-cache" in docker["environment"]
     assert "HOME=/raid/buildkite/home" in docker["environment"]
     assert "XDG_CACHE_HOME=/raid/buildkite/cache" in docker["environment"]
-    assert "FLASHINFER_CUBIN_DIR=/raid/buildkite/flashinfer-cubins" in docker["environment"]
+    assert (
+        "/raid/buildkite/flashinfer-cubins-sglang:"
+        "/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins"
+    ) in docker["volumes"]
 
 
 def test_run_command_preserves_injected_hf_home():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -52,6 +52,21 @@ def test_b200_uses_podspec_patch_to_override_agent_container():
         "path": "/dev/infiniband",
         "type": "Directory",
     }
+    assert "nodeName" not in patch
+
+
+def test_b200_node_name_override_is_opt_in():
+    key = "B200_NODE_NAME"
+    prev = os.environ.get(key)
+    os.environ[key] = "dgxB200-12"
+    try:
+        patch = _b200_patch("lmsysorg/sglang:latest", 8)
+    finally:
+        if prev is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prev
+    assert patch["nodeName"] == "dgxB200-12"
 
 
 def test_native_runtime_venv_keeps_image_packages_visible():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -223,6 +223,7 @@ def test_glm_b300_sglang_uses_matched_real_eagle_shape():
     for expected in (
         "--tp 8",
         "--dp 8",
+        "--ep-size 8",
         "--enable-dp-attention",
         "--moe-a2a-backend none",
         "--moe-runner-backend triton",

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -167,6 +167,8 @@ def test_b300_profile_uses_standalone_docker_plugin():
     plugin = g.nvidia_docker_plugin("example/sglang:test", 8, profile, "B300")
     docker = plugin["docker#v5.2.0"]
     assert profile["queue"] == "b300-8"
+    assert docker["entrypoint"] == ""
+    assert docker["shell"] == ["/bin/sh", "-e", "-c"]
     assert docker["gpus"] == "all"
     assert docker["network"] == "host"
     assert docker["ipc"] == "host"

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -52,10 +52,10 @@ def test_b200_uses_podspec_patch_to_override_agent_container():
         "path": "/dev/infiniband",
         "type": "Directory",
     }
-    assert "nodeName" not in patch
+    assert "nodeSelector" not in patch
 
 
-def test_b200_node_name_override_is_opt_in():
+def test_b200_node_name_override_adds_hostname_selector():
     key = "B200_NODE_NAME"
     prev = os.environ.get(key)
     os.environ[key] = "dgxB200-12"
@@ -66,7 +66,7 @@ def test_b200_node_name_override_is_opt_in():
             os.environ.pop(key, None)
         else:
             os.environ[key] = prev
-    assert patch["nodeName"] == "dgxB200-12"
+    assert patch["nodeSelector"] == {"kubernetes.io/hostname": "dgxB200-12"}
 
 
 def test_native_runtime_venv_keeps_image_packages_visible():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -224,7 +224,7 @@ def test_glm_b300_sglang_uses_matched_real_eagle_shape():
         "--tp 8",
         "--dp 8",
         "--enable-dp-attention",
-        "--moe-a2a-backend deepep",
+        "--moe-a2a-backend flashinfer",
         "--kv-cache-dtype fp8_e4m3",
         "--speculative-algorithm EAGLE",
         "--speculative-num-steps 1",

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -46,7 +46,12 @@ def test_b200_uses_podspec_patch_to_override_agent_container():
     assert c["securityContext"]["privileged"] is True
     assert "SYS_ADMIN" in c["securityContext"]["capabilities"]["add"]
     mounts = {m["name"]: m["mountPath"] for m in c["volumeMounts"]}
-    assert "infiniband" not in mounts
+    volumes = {v["name"]: v for v in patch["volumes"]}
+    assert mounts["infiniband"] == "/dev/infiniband"
+    assert volumes["infiniband"]["hostPath"] == {
+        "path": "/dev/infiniband",
+        "type": "Directory",
+    }
     assert "nodeSelector" not in patch
 
 

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -28,6 +28,22 @@ def _amd_volumes(profile, gpu="MI300X"):
     return patch, vols
 
 
+def _b200_patch(image="img", num_gpus=8):
+    plugin = g.b200_k8s_plugin(image, num_gpus, {}, "B200")
+    return plugin["kubernetes"]["podSpecPatch"]
+
+
+def test_b200_uses_podspec_patch_to_override_agent_container():
+    """The B200 Kubernetes stack runs commands in its pre-created build
+    container, so the workload image must patch container-0 instead of adding a
+    separate unnamed container that the agent ignores."""
+    patch = _b200_patch("lmsysorg/sglang:latest", 8)
+    c = patch["containers"][0]
+    assert c["name"] == "container-0"
+    assert c["image"] == "lmsysorg/sglang:latest"
+    assert c["resources"]["limits"]["nvidia.com/gpu"] == 8
+
+
 def test_default_hf_cache_is_emptydir_not_hostpath():
     """Default (no override, no profile field) must be an emptyDir, never a
     hostPath — a hostPath on an unmounted node path is what filled root disks."""

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -44,6 +44,26 @@ def test_b200_uses_podspec_patch_to_override_agent_container():
     assert c["resources"]["limits"]["nvidia.com/gpu"] == 8
 
 
+def test_native_runtime_venv_keeps_image_packages_visible():
+    """Native runtimes use packages already installed in the workload image
+    (`vllm`, `sglang`). The helper venv is only for pyyaml/lm-eval, so it must
+    include system site packages."""
+    profiles = {"B200": g.load_profiles()["B200"]}
+    step = g.make_step(
+        "workloads/glm_5_2_sglang_b200.yaml",
+        {
+            "name": "glm_5_2-sglang-b200",
+            "gpu": "B200",
+            "num_gpus": 8,
+            "bench_only": True,
+            "sglang": {"model": "zai-org/GLM-5.2-FP8"},
+            "sglang_bench": {"configs": []},
+        },
+        profiles,
+    )
+    assert "python3 -m venv --system-site-packages .venv" in step["commands"][0]
+
+
 def test_default_hf_cache_is_emptydir_not_hostpath():
     """Default (no override, no profile field) must be an emptyDir, never a
     hostPath — a hostPath on an unmounted node path is what filled root disks."""

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -161,6 +161,46 @@ def test_shipped_amd_profiles_have_no_rootdisk_hostpath():
         )
 
 
+def test_b300_profile_uses_standalone_docker_plugin():
+    profiles = g.load_profiles()
+    profile = profiles["B300"]
+    plugin = g.nvidia_docker_plugin("example/sglang:test", 8, profile, "B300")
+    docker = plugin["docker#v5.2.0"]
+    assert profile["queue"] == "b300-8"
+    assert docker["gpus"] == "all"
+    assert docker["network"] == "host"
+    assert docker["ipc"] == "host"
+    assert "memlock=-1" in docker["ulimits"]
+    assert "/raid:/raid" in docker["volumes"]
+    assert "HF_HOME=/raid/inf-simon/hf-cache" in docker["environment"]
+
+
+def test_run_command_preserves_injected_hf_home():
+    rendered = g.RUN_TEMPLATE.format(path="workloads/example.yaml")
+    assert 'HF_HOME="$${HF_HOME:-$(pwd)/.hf-cache}"' in rendered
+
+
+def test_b300_sglang_workload_renders_docker_plugin_step():
+    profiles = g.load_profiles()
+    step = g.make_step(
+        "workloads/glm_5_2_sglang_b200.yaml",
+        {
+            "name": "glm_5_2-sglang-b300",
+            "gpu": "B300",
+            "num_gpus": 8,
+            "bench_only": True,
+            "sglang": {
+                "model": "/raid/inf-simon/models/zai-org/GLM-5.2-FP8",
+                "image": "example/sglang:test",
+            },
+            "sglang_bench": {"configs": []},
+        },
+        profiles,
+    )
+    assert step["agents"] == {"queue": "b300-8"}
+    assert step["plugins"][0]["docker#v5.2.0"]["image"] == "example/sglang:test"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -173,6 +173,7 @@ def test_b300_profile_uses_standalone_docker_plugin():
     assert docker["gpus"] == "all"
     assert docker["network"] == "host"
     assert docker["ipc"] == "host"
+    assert docker["add-caps"] == ["SYS_PTRACE"]
     assert "memlock=-1" in docker["ulimits"]
     assert "/raid:/raid" in docker["volumes"]
     assert "HF_HOME=/raid/buildkite/hf-cache" in docker["environment"]
@@ -225,6 +226,7 @@ def test_glm_b300_sglang_uses_matched_real_eagle_shape():
         "--dp 8",
         "--enable-dp-attention",
         "--moe-a2a-backend flashinfer",
+        "--moe-runner-backend flashinfer_cutlass",
         "--kv-cache-dtype fp8_e4m3",
         "--speculative-algorithm EAGLE",
         "--speculative-num-steps 1",

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -173,7 +173,6 @@ def test_b300_profile_uses_standalone_docker_plugin():
     assert docker["gpus"] == "all"
     assert docker["network"] == "host"
     assert docker["ipc"] == "host"
-    assert docker["add-caps"] == ["SYS_PTRACE"]
     assert "memlock=-1" in docker["ulimits"]
     assert "/raid:/raid" in docker["volumes"]
     assert "HF_HOME=/raid/buildkite/hf-cache" in docker["environment"]
@@ -225,8 +224,7 @@ def test_glm_b300_sglang_uses_matched_real_eagle_shape():
         "--tp 8",
         "--dp 8",
         "--enable-dp-attention",
-        "--moe-a2a-backend flashinfer",
-        "--moe-runner-backend flashinfer_cutlass",
+        "--moe-a2a-backend none",
         "--kv-cache-dtype fp8_e4m3",
         "--speculative-algorithm EAGLE",
         "--speculative-num-steps 1",

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -225,6 +225,7 @@ def test_glm_b300_sglang_uses_matched_real_eagle_shape():
         "--dp 8",
         "--enable-dp-attention",
         "--moe-a2a-backend none",
+        "--moe-runner-backend deep_gemm",
         "--kv-cache-dtype fp8_e4m3",
         "--speculative-algorithm EAGLE",
         "--speculative-num-steps 1",

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -46,12 +46,7 @@ def test_b200_uses_podspec_patch_to_override_agent_container():
     assert c["securityContext"]["privileged"] is True
     assert "SYS_ADMIN" in c["securityContext"]["capabilities"]["add"]
     mounts = {m["name"]: m["mountPath"] for m in c["volumeMounts"]}
-    volumes = {v["name"]: v for v in patch["volumes"]}
-    assert mounts["infiniband"] == "/dev/infiniband"
-    assert volumes["infiniband"]["hostPath"] == {
-        "path": "/dev/infiniband",
-        "type": "Directory",
-    }
+    assert "infiniband" not in mounts
     assert "nodeSelector" not in patch
 
 

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -212,6 +212,40 @@ def test_b300_sglang_workload_renders_docker_plugin_step():
     assert step["plugins"][0]["docker#v5.2.0"]["image"] == "example/sglang:test"
 
 
+def test_glm_b300_sglang_uses_matched_real_eagle_shape():
+    path = os.path.join(
+        os.path.dirname(HERE), "workloads", "glm_5_2_sglang_b200.yaml"
+    )
+    with open(path) as f:
+        data = g.yaml.safe_load(f)
+    sglang = data["sglang"]
+    args = sglang["serve_args"]
+    for expected in (
+        "--tp 8",
+        "--dp 8",
+        "--enable-dp-attention",
+        "--moe-a2a-backend deepep",
+        "--kv-cache-dtype fp8_e4m3",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 1",
+        "--speculative-num-draft-tokens 2",
+        "--mem-fraction-static 0.85",
+        "--context-length 32768",
+        "--chunked-prefill-size 32768",
+        "--max-prefill-tokens 32768",
+        "--max-running-requests 256",
+        "--disable-radix-cache",
+    ):
+        assert expected in args
+    assert sglang["env"]["NVSHMEM_DISABLE_IB"] == 1
+    assert "SGLANG_SIMULATE_ACC_LEN" not in sglang["env"]
+    configs = data["sglang_bench"]["configs"]
+    assert [(c["num_prompts"], c["max_concurrency"]) for c in configs] == [
+        (128, 64),
+        (512, 256),
+    ]
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Pipeline metadata:
    - `commit: "<full SHA>"`
    - `branch: "<branch name>"` (use the actual branch, not `main`, when testing a feature branch)
    - `message: "<short description of what this tests>"` — match the existing convention: short, action-oriented (e.g. "Add gpqa diamond", "Writable HF_HOME for lm_eval datasets cache"). No emoji unless the user asks.
-   - `environment`: always pass both `VLLM_COMMIT` (the vLLM SHA being tested) and `VLLM_IMAGE` (the full Docker image URI). Optionally pass `WORKLOADS` for an explicit workload list; omit it to run all `nightly: true` workloads.
+   - `environment`: for vLLM workloads, always pass both `VLLM_COMMIT` (the vLLM SHA being tested) and `VLLM_IMAGE` (the full Docker image URI). For SGLang workloads, pass `SGLANG_IMAGE` when testing a specific SGLang image; otherwise the workload's `sglang.image` is used. Optionally pass `WORKLOADS` for an explicit workload list; omit it to run all `nightly: true` workloads.
 
    With `bk` (run `bk auth status` first):
 
@@ -85,7 +85,7 @@ Pipeline metadata:
      --env "WORKLOADS=<optional workload list>"
    ```
 
-   Omit the final `WORKLOADS` argument to run every `nightly: true` workload.
+   Omit the final `WORKLOADS` argument to run every `nightly: true` workload. For SGLang-only opt-in runs, use `--env "SGLANG_IMAGE=<full Docker image URI>"` instead of the vLLM image envs.
 3. **Report the build URL** back to the user immediately so they can follow
    along. MCP returns it as `web_url`; `bk build create` prints it in the build
    summary.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ CLAUDE.md         agent conventions and detailed Buildkite workflow
 B200 workloads run in a single Kubernetes pod. `num_gpus` controls the pod's
 GPU allocation; use at most 8 GPUs to keep the workload on one B200 node.
 
+Standalone B300 workloads run on the `b300-8` queue through the Buildkite
+Docker plugin. The profile exposes all eight GPUs, uses host networking and
+IPC, mounts `/raid`, and persists Hugging Face data under
+`/raid/inf-simon/hf-cache`. Before a large workload, validate the runner with
+`WORKLOADS=b300_runner_smoke`.
+
 ### Recipe schema
 
 A recipe has top-level metadata plus server and eval blocks:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # perf-eval
 
-Run accuracy + perf workloads against vLLM, defined by small YAML recipes in `workloads/`.
+Run accuracy + perf workloads against vLLM and SGLang, defined by small YAML recipes in `workloads/`.
 
 Each recipe is one `(model, hardware, set of tasks)` combination. The Buildkite pipeline picks recipes up automatically — to ship a new run, you write a YAML file, push it, and trigger a build.
 
@@ -27,14 +27,16 @@ GPU allocation; use at most 8 GPUs to keep the workload on one B200 node.
 
 ### Recipe schema
 
-A recipe has top-level metadata plus up to three eval blocks:
+A recipe has top-level metadata plus server and eval blocks:
 
-- **`vllm:`** — *how the server runs.* Defines what model to serve and how (`model`, `serve_args`, optional image/env overrides). Required.
+- **`vllm:`** — *how a vLLM server runs.* Defines what model to serve and how (`model`, `serve_args`, optional image/env overrides). Use either `vllm:` or `sglang:`.
+- **`sglang:`** — *how an SGLang server runs.* Defines the model, SGLang image/env, and args appended to `python3 -m sglang.launch_server --model-path <model> --host 0.0.0.0 --port <port>`.
 - **`lm_eval:`** — *what accuracy to measure.* Lists lm-evaluation-harness tasks to run against the live server (e.g. `gsm8k`, `aime25`). Each task's score is saved under `results/<name>/<task-name>/`. Optional.
 - **`vllm_bench:`** — *what perf to measure.* Lists `vllm bench serve` configs (input/output lengths, concurrency, dataset). Raw JSON is saved and ingested into the perf dashboard. Optional.
+- **`sglang_bench:`** — *what SGLang perf to measure.* Lists `python3 -m sglang.bench_serving` configs. Raw JSONL plus the final JSON row are saved and ingested into the perf dashboard with `framework=sglang`. Optional.
 - **`bfcl:`** — *function-calling eval.* Runs [BFCL](https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard) test categories against the live server. Some models need `--enable-auto-tool-choice` and `--tool-call-parser` in `serve_args`. Results are transformed to lm_eval format and ingested as `bfcl_<category>` tasks. Optional.
 
-Include one or more of `lm_eval:` / `vllm_bench:` / `bfcl:` depending on what you want out of this recipe.
+Include one or more of `lm_eval:` / `vllm_bench:` / `sglang_bench:` / `bfcl:` depending on what you want out of this recipe.
 
 ```yaml
 name: qwen3_5-h200       # used in container name and results/<name>/
@@ -87,6 +89,28 @@ vllm_bench:              # perf runs (optional) — fed to the perf dashboard
       args:                             # optional vllm bench serve arguments
         num_warmups: 16                 # becomes --num-warmups 16
         disable_tqdm: true              # becomes --disable-tqdm
+
+sglang:                 # alternative server block for SGLang workloads
+  model: zai-org/GLM-5.2-FP8
+  image: lmsysorg/sglang:latest          # optional; falls back to SGLANG_IMAGE / latest
+  env:
+    SGLANG_SIMULATE_ACC_LEN: 2
+  serve_args: >-                         # appended to python3 -m sglang.launch_server ...
+    --tp 8 --dp 8
+    --enable-dp-attention
+
+sglang_bench:           # SGLang perf runs (optional) — fed to the perf dashboard
+  metadata:
+    tp: 8                # physical GPUs for per-GPU dashboard throughput
+    precision: fp8
+  configs:
+    - name: 8k-in-1k-out-conc-64
+      backend: sglang
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 128
+      max_concurrency: 64
 ```
 
 A few things worth knowing:
@@ -97,6 +121,7 @@ A few things worth knowing:
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
 - **`vllm_bench` uses the `random` dataset with `--ignore-eos`** so every request prefills exactly `input_len` and decodes exactly `output_len` tokens — that's what makes the per-GPU decode throughput meaningful. Pair it with `backend: openai` (the `/v1/completions` endpoint) for exact token control. Avoid `dataset: speed_bench` for throughput numbers: it requires `--skip-tokenizer-init`, which makes `vllm bench serve` cap every request at a single output token, so output throughput reads as ~0.
 - **`vllm_bench.configs[].args` forwards additional options to `vllm bench serve`.** Keys may use underscores, hyphens, or a leading `--`; they are normalized to `--kebab-case`. A `true` value emits a standalone flag, `false` and `null` omit it, scalar values emit a flag/value pair, and lists repeat the flag. Options managed by perf-eval itself, including the model, endpoint, dataset, request counts, lengths, concurrency, and result path, remain top-level config fields and cannot be overridden through `args`.
+- **`sglang_bench` currently supports the `random` dataset.** It runs `python3 -m sglang.bench_serving` with `--random-range-ratio 1.0`, `--warmup-requests 64`, and `--flush-cache`, matching SGLang's published GLM-5.2 serving recipes. Set `metadata.tp` to the physical GPU count used for per-GPU dashboard throughput; SGLang DP-attention recipes can use both `--tp` and `--dp` without consuming `tp * dp` GPUs.
 - **`bfcl` may need tool-call serve args.** Some models require `--enable-auto-tool-choice` and `--tool-call-parser` for function-calling; the parser warns if `--tool-call-parser` is absent. Each category runs as a separate generate + evaluate pass; scores appear on the eval dashboard as `bfcl_<category>` tasks.
 - **`bfcl.maximum_step_limit`** caps how many inference steps BFCL allows per multi-turn turn (default 10 in perf-eval; BFCL upstream defaults to 20). Set it in the workload YAML, or override per-run with the `BFCL_MAXIMUM_STEP_LIMIT` env var (env wins over YAML). Useful for agentic / long multi-turn categories.
 - **`bfcl.max_test_cases`** subsamples a category instead of running the full set — e.g. `multi_turn` (~800 cases) down to 300. For aggregate groups with multiple subcategories, the cap is split evenly across subcategories (by BFCL id order within each). Set a single integer to cap every category, or a map per category (`multi_turn: 240`). Override per-run with `BFCL_MAX_TEST_CASES`. Scores are partial-eval only and are not comparable to full BFCL leaderboard numbers.
@@ -127,7 +152,7 @@ The pipeline is [**`vllm/perf-eval`**](https://buildkite.com/vllm/perf-eval). Wi
 
 **From the UI:** open the pipeline → New Build → pick branch and commit (must be pushed to GitHub) → optionally fill Environment Variables to scope the run → Create Build.
 
-**Required env vars** — both must be set on every build:
+**Required env vars for vLLM image override builds** — both must be set when testing a specific vLLM revision:
 
 - `VLLM_COMMIT` — vLLM commit SHA being tested. Used to tag results and track which vLLM version produced them.
 - `VLLM_IMAGE` — full Docker image URI (e.g. `vllm/vllm-openai:nightly-abc1234`). This is the image that gets pulled and run.
@@ -135,6 +160,7 @@ The pipeline is [**`vllm/perf-eval`**](https://buildkite.com/vllm/perf-eval). Wi
 **Optional env vars:**
 
 - `WORKLOADS` — comma- or newline-separated list of workload paths or stems. Runs exactly those instead of the default `nightly: true` set.
+- `SGLANG_IMAGE` — full Docker image URI for SGLang workloads. Overrides `sglang.image` in the workload.
 - `NIGHTLY` — set to `1` to tag every ingested row with `nightly: true`. The dashboard's `/nightly` view filters on this to pair adjacent nightly builds; only the scheduled nightly cron should set it.
 
 **Example — trigger a build from the Buildkite UI:**

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -23,6 +23,10 @@ B300:
   # The standalone Axis host keeps validated framework images locally; avoid
   # re-pulling multi-gigabyte images on every opt-in benchmark invocation.
   always_pull: false
+  # FlashInfer NVLink A2A shares CUDA IPC handles between DP workers via
+  # pidfd_getfd(2), which Docker's default capability set blocks.
+  add_caps:
+    - SYS_PTRACE
   # Keep SGLang's flashinfer-cubin version isolated from the vLLM image while
   # allowing its runtime-created TRT-LLM symlinks under an arbitrary UID.
   extra_volumes:

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -15,6 +15,18 @@ B200:
     VLLM_DEEP_GEMM_WARMUP: skip
     NCCL_CUMEM_HOST_ENABLE: 0
 
+B300:
+  queue: b300-8
+  hf_home: /raid/inf-simon/hf-cache
+  server_runtime: native
+  docker_plugin: nvidia
+  # The standalone Axis host keeps validated framework images locally; avoid
+  # re-pulling multi-gigabyte images on every opt-in benchmark invocation.
+  always_pull: false
+  env:
+    VLLM_DEEP_GEMM_WARMUP: skip
+    NCCL_CUMEM_HOST_ENABLE: 0
+
 MI300X:
   queue: mi300_perf_eval
   image_repo: vllm/vllm-openai-rocm

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -23,6 +23,10 @@ B300:
   # The standalone Axis host keeps validated framework images locally; avoid
   # re-pulling multi-gigabyte images on every opt-in benchmark invocation.
   always_pull: false
+  # Keep SGLang's flashinfer-cubin version isolated from the vLLM image while
+  # allowing its runtime-created TRT-LLM symlinks under an arbitrary UID.
+  extra_volumes:
+    - /raid/buildkite/flashinfer-cubins-sglang:/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins
   env:
     VLLM_DEEP_GEMM_WARMUP: skip
     NCCL_CUMEM_HOST_ENABLE: 0

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -17,7 +17,7 @@ B200:
 
 B300:
   queue: b300-8
-  hf_home: /raid/inf-simon/hf-cache
+  hf_home: /raid/buildkite/hf-cache
   server_runtime: native
   docker_plugin: nvidia
   # The standalone Axis host keeps validated framework images locally; avoid

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -23,10 +23,6 @@ B300:
   # The standalone Axis host keeps validated framework images locally; avoid
   # re-pulling multi-gigabyte images on every opt-in benchmark invocation.
   always_pull: false
-  # FlashInfer NVLink A2A shares CUDA IPC handles between DP workers via
-  # pidfd_getfd(2), which Docker's default capability set blocks.
-  add_caps:
-    - SYS_PTRACE
   # Keep SGLang's flashinfer-cubin version isolated from the vLLM image while
   # allowing its runtime-created TRT-LLM symlinks under an arbitrary UID.
   extra_volumes:

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -27,6 +27,10 @@ B300:
   # allowing its runtime-created TRT-LLM symlinks under an arbitrary UID.
   extra_volumes:
     - /raid/buildkite/flashinfer-cubins-sglang:/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins
+    # Torch resolves a cache namespace through getpwuid(); expose the host's
+    # service-account entry when the image runs as the propagated agent UID.
+    - /etc/passwd:/etc/passwd:ro
+    - /etc/group:/etc/group:ro
   env:
     VLLM_DEEP_GEMM_WARMUP: skip
     NCCL_CUMEM_HOST_ENABLE: 0

--- a/lib/ingest_perf.py
+++ b/lib/ingest_perf.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Transform a `vllm bench serve` raw JSON result and POST it to the perf
+"""Transform a serving benchmark raw JSON result and POST it to the perf
 dashboard's ingestion endpoint.
 
 The dashboard at perf.vllm.ai reads from the `vllm_perf_data_ingest`
 Databricks table; that table is populated by the Cloud Run endpoint pinged
 here. Schema modeled after vllm-project/perf-dashboard/benchmark/process_result.py.
+
+Supports raw JSON from `vllm bench serve` and the final JSONL row from
+`python3 -m sglang.bench_serving`.
 
 Latencies in the raw result are in milliseconds (e.g., `mean_ttft_ms`).
 The dashboard expects seconds, so the transform drops the `_ms` suffix and
@@ -42,11 +45,15 @@ def post(endpoint: str, payload: dict) -> None:
 
 
 def transform(raw: dict, args: argparse.Namespace) -> dict:
-    """Map the raw `vllm bench serve` JSON to the dashboard's row shape."""
+    """Map a raw benchmark JSON object to the dashboard's row shape."""
     tp = max(args.tp, 1)
-    total_token_throughput = float(raw.get("total_token_throughput", 0) or 0)
+    total_token_throughput = float(
+        raw.get("total_token_throughput", raw.get("total_throughput", 0)) or 0
+    )
     output_throughput = float(raw.get("output_throughput", 0) or 0)
-    input_throughput = total_token_throughput - output_throughput
+    input_throughput = float(
+        raw.get("input_throughput", total_token_throughput - output_throughput) or 0
+    )
 
     data = {
         "date": args.date or datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
@@ -54,7 +61,7 @@ def transform(raw: dict, args: argparse.Namespace) -> dict:
         "conc": int(raw.get("max_concurrency") or args.conc),
         "image": args.image,
         "model": raw.get("model_id") or args.model,
-        "framework": "vllm",
+        "framework": args.framework,
         "precision": args.precision,
         "spec_decoding": "false",
         "disagg": "false",
@@ -91,7 +98,8 @@ def transform(raw: dict, args: argparse.Namespace) -> dict:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--raw-result", required=True, help="Raw JSON from `vllm bench serve --save-result`")
+    p.add_argument("--raw-result", required=True, help="Raw JSON from the benchmark client")
+    p.add_argument("--framework", default="vllm", choices=("vllm", "sglang"), help="Serving framework tag")
     p.add_argument("--device", required=True, help="Device tag (e.g. h200)")
     p.add_argument("--tp", type=int, required=True, help="Effective parallel-degree (TP * DP)")
     p.add_argument("--precision", required=True, help="Precision tag (e.g. fp8, bf16)")

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -4,12 +4,16 @@ Usage: eval "$(python3 lib/parse_workload.py workloads/foo.yaml)"
 
 The README documents the recipe schema. This script validates it and
 projects it into shell variables: top-level metadata, server config
-(image, model, serve_args, env, runtime), the lm_eval task list, the
-vllm_bench config list, and bench ingest metadata (device/tp/precision).
+(engine, image, model, serve_args, env, runtime), the lm_eval task list, the
+vllm_bench / sglang_bench config lists, and bench ingest metadata
+(device/tp/precision).
 
 Image precedence: VLLM_IMAGE > VLLM_COMMIT > workload `vllm.image` >
 `vllm/vllm-openai:latest`. When BENCH_ONLY is truthy, lm_eval task names
 are not validated against the registry (because they will not run).
+
+SGLang workloads use a top-level `sglang:` block. Image precedence is
+SGLANG_IMAGE > workload `sglang.image` > `lmsysorg/sglang:latest`.
 """
 
 import base64
@@ -35,6 +39,11 @@ BENCH_RESERVED_ARGS = {
     "speed-bench-output-len", "speed-bench-dataset-subset",
     "speed-bench-category", "skip-tokenizer-init", "save-result",
     "result-filename",
+}
+SGLANG_BENCH_RESERVED_ARGS = {
+    "backend", "host", "port", "model", "dataset-name", "num-prompts",
+    "max-concurrency", "random-input-len", "random-output-len",
+    "random-range-ratio", "warmup-requests", "flush-cache", "output-file",
 }
 BFCL_FIELDS = {
     "test_categories", "num_threads", "temperature",
@@ -102,8 +111,25 @@ def load_profile(gpu: str, workload_path: str) -> dict:
     return profiles[gpu]
 
 
-def resolve_image(vllm: dict, profile: dict) -> tuple[str, str]:
+def server_config(data: dict, path: str) -> tuple[str, dict]:
+    has_vllm = bool(data.get("vllm"))
+    has_sglang = bool(data.get("sglang"))
+    if has_vllm and has_sglang:
+        sys.exit(f"{path}: define only one of `vllm:` or `sglang:`")
+    if has_sglang:
+        return "sglang", data.get("sglang") or {}
+    return "vllm", data.get("vllm") or {}
+
+
+def resolve_image(engine: str, server: dict, profile: dict) -> tuple[str, str]:
     """Pick the image and commit using VLLM_IMAGE / VLLM_COMMIT / workload."""
+    if engine == "sglang":
+        override_image = (os.environ.get("SGLANG_IMAGE") or "").strip()
+        if override_image:
+            return override_image, commit_from_image(override_image)
+        image = server.get("image", "lmsysorg/sglang:latest")
+        return image, commit_from_image(str(image))
+
     override_image = (os.environ.get("VLLM_IMAGE") or "").strip()
     override_commit = (os.environ.get("VLLM_COMMIT") or "").strip()
     # ROCm images are located at vllm/vllm-openai-rocm. The default
@@ -118,7 +144,7 @@ def resolve_image(vllm: dict, profile: dict) -> tuple[str, str]:
     if commit:
         return f"{repo}:nightly-{commit}", commit
 
-    image = vllm.get("image", f"{repo}:nightly")
+    image = server.get("image", f"{repo}:nightly")
     return image, commit_from_image(str(image))
 
 
@@ -188,26 +214,35 @@ def normalize_bench_arg_name(name: str) -> str:
     return name.lstrip("-").replace("_", "-")
 
 
-def encode_bench_args(args: object, config_name: str, path: str) -> str:
+def encode_bench_args(
+    args: object,
+    config_name: str,
+    path: str,
+    block_name: str = "vllm_bench",
+) -> str:
     if args is None:
         args = {}
     if not isinstance(args, dict):
-        sys.exit(f"{path}: vllm_bench config {config_name!r} args must be a map")
+        sys.exit(f"{path}: {block_name} config {config_name!r} args must be a map")
+    reserved = (
+        SGLANG_BENCH_RESERVED_ARGS if block_name == "sglang_bench"
+        else BENCH_RESERVED_ARGS
+    )
     normalized = {}
     for name, value in args.items():
         if not isinstance(name, str) or not normalize_bench_arg_name(name):
             sys.exit(
-                f"{path}: vllm_bench config {config_name!r} args keys must be non-empty strings"
+                f"{path}: {block_name} config {config_name!r} args keys must be non-empty strings"
             )
         normalized_name = normalize_bench_arg_name(name)
-        if normalized_name in BENCH_RESERVED_ARGS:
+        if normalized_name in reserved:
             sys.exit(
-                f"{path}: vllm_bench config {config_name!r} args cannot override "
+                f"{path}: {block_name} config {config_name!r} args cannot override "
                 f"wrapper-owned option --{normalized_name}"
             )
         if normalized_name in normalized:
             sys.exit(
-                f"{path}: vllm_bench config {config_name!r} args contains duplicate "
+                f"{path}: {block_name} config {config_name!r} args contains duplicate "
                 f"option --{normalized_name} after normalization"
             )
         normalized[normalized_name] = value
@@ -215,21 +250,21 @@ def encode_bench_args(args: object, config_name: str, path: str) -> str:
     return base64.b64encode(payload).decode()
 
 
-def bench_tsv(configs: list, path: str) -> str:
+def bench_tsv(configs: list, path: str, block_name: str = "vllm_bench") -> str:
     seen = set()
     lines = []
     for c in configs:
         extra = set(c) - BENCH_FIELDS
         if extra:
             sys.exit(
-                f"{path}: vllm_bench config {c.get('name')!r} has unsupported "
+                f"{path}: {block_name} config {c.get('name')!r} has unsupported "
                 f"fields {sorted(extra)}; allowed: {sorted(BENCH_FIELDS)}"
             )
         for k in BENCH_REQUIRED:
             if c.get(k) is None:
-                sys.exit(f"{path}: vllm_bench config {c.get('name')!r} missing required field {k!r}")
+                sys.exit(f"{path}: {block_name} config {c.get('name')!r} missing required field {k!r}")
         if c["name"] in seen:
-            sys.exit(f"{path}: duplicate vllm_bench config name {c['name']!r}")
+            sys.exit(f"{path}: duplicate {block_name} config name {c['name']!r}")
         seen.add(c["name"])
 
         def opt(key):
@@ -248,7 +283,7 @@ def bench_tsv(configs: list, path: str) -> str:
                     str(c["max_concurrency"]),
                     opt("speed_bench_dataset_subset"),
                     opt("speed_bench_category"),
-                    encode_bench_args(c.get("args"), c["name"], path),
+                    encode_bench_args(c.get("args"), c["name"], path, block_name),
                 ]
             )
         )
@@ -338,51 +373,57 @@ def main(path: str) -> None:
     if not gpu:
         sys.exit(f"{path}: missing required 'gpu' field")
     profile = load_profile(gpu, path)
-    vllm = data.get("vllm") or {}
+    engine, server = server_config(data, path)
     lm_eval = data.get("lm_eval") or {}
-    bench = data.get("vllm_bench") or {}
+    vllm_bench = data.get("vllm_bench") or {}
+    sglang_bench = data.get("sglang_bench") or {}
 
     tasks = lm_eval.get("tasks") or []
     bfcl = data.get("bfcl") or {}
-    bench_configs = bench.get("configs") or []
+    vllm_bench_configs = vllm_bench.get("configs") or []
+    sglang_bench_configs = sglang_bench.get("configs") or []
 
-    if not tasks and not bench_configs and not bfcl:
+    if not tasks and not vllm_bench_configs and not sglang_bench_configs and not bfcl:
         sys.exit(
-            f"{path}: workload must define at least one of lm_eval, vllm_bench, or bfcl"
+            f"{path}: workload must define at least one of lm_eval, vllm_bench, sglang_bench, or bfcl"
         )
 
     if tasks:
         validate_tasks(tasks, path)
 
-    serve_args = vllm.get("serve_args") or ""
+    serve_args = server.get("serve_args") or ""
     if bfcl:
         validate_bfcl(bfcl, serve_args, path)
 
-    image, vllm_commit = resolve_image(vllm, profile)
-    env = {**(profile.get("env") or {}), **(vllm.get("env") or {})}
+    image, version_commit = resolve_image(engine, server, profile)
+    env = {**(profile.get("env") or {}), **(server.get("env") or {})}
     if "HF_HOME" not in env and profile.get("hf_home"):
         env["HF_HOME"] = profile["hf_home"]
 
-    metadata = bench.get("metadata") or {}
+    metadata = (
+        sglang_bench.get("metadata") or vllm_bench.get("metadata") or {}
+    )
     tp = metadata.get("tp")
     if tp is None:
         tp = parse_tp(serve_args)
 
     emit("NAME", data.get("name", ""))
+    emit("ENGINE", engine)
     emit("IMAGE", image)
-    emit("VLLM_COMMIT", vllm_commit)
-    emit("MODEL", vllm.get("model", ""))
+    emit("VLLM_COMMIT", version_commit)
+    emit("MODEL", server.get("model", ""))
     emit("SERVE_ARGS", serve_args)
     emit("SERVER_RUNTIME", profile.get("server_runtime", "docker"))
     emit("ENV", "\n".join(f"{k}={fmt(v)}" for k, v in env.items()))
     emit("LM_EVAL_TASKS_TSV", task_tsv(tasks, lm_eval.get("model_args") or {}))
-    emit("VLLM_BENCH_TSV", bench_tsv(bench_configs, path))
+    emit("VLLM_BENCH_TSV", bench_tsv(vllm_bench_configs, path))
+    emit("SGLANG_BENCH_TSV", bench_tsv(sglang_bench_configs, path, "sglang_bench"))
     emit("BFCL_TSV", bfcl_tsv(bfcl) if bfcl else "")
     emit("BENCH_DEVICE", metadata.get("device") or gpu.lower())
     emit("BENCH_TP", tp)
     emit(
         "BENCH_PRECISION",
-        metadata.get("precision") or precision_from_model(vllm.get("model") or ""),
+        metadata.get("precision") or precision_from_model(server.get("model") or ""),
     )
 
 

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Orchestrate a workload: bring up vLLM, then dispatch each task to the
+# Orchestrate a workload: bring up the model server, then dispatch each task to the
 # helper script for its type.
 #
 # Usage: ./lib/run.sh workloads/qwen3_5_h200.yaml
@@ -15,9 +15,11 @@ source "$DIR/server.sh"
 source "$DIR/run_lm_eval.sh"
 # shellcheck disable=SC1091
 source "$DIR/run_vllm_bench.sh"
+# shellcheck disable=SC1091
+source "$DIR/run_sglang_bench.sh"
 WORKLOAD_EXPORTS="$(python3 "$DIR/parse_workload.py" "$WORKLOAD")"
 eval "$WORKLOAD_EXPORTS"
-export WORKLOAD_IMAGE WORKLOAD_VLLM_COMMIT WORKLOAD_SERVER_RUNTIME
+export WORKLOAD_ENGINE WORKLOAD_IMAGE WORKLOAD_VLLM_COMMIT WORKLOAD_SERVER_RUNTIME
 
 PORT=8000
 CONTAINER="perf-eval-${WORKLOAD_NAME}-$$"
@@ -33,7 +35,8 @@ mkdir -p "$RESULTS_DIR"
 trap 'stop_server "$CONTAINER"' EXIT
 
 start_server "$CONTAINER" "$PORT" "$WORKLOAD_IMAGE" "$WORKLOAD_MODEL" \
-             "$WORKLOAD_SERVE_ARGS" "$WORKLOAD_ENV" "$WORKLOAD_SERVER_RUNTIME"
+             "$WORKLOAD_SERVE_ARGS" "$WORKLOAD_ENV" "$WORKLOAD_SERVER_RUNTIME" \
+             "$WORKLOAD_ENGINE"
 wait_healthy "$PORT"
 
 # vllm bench serve runs first so we can validate perf flow without waiting
@@ -56,6 +59,23 @@ while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc speed_subset
     --image "$WORKLOAD_IMAGE" \
     --isl "$isl" --osl "$osl" --conc "$conc" || true
 done <<< "$WORKLOAD_VLLM_BENCH_TSV"
+
+while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc _speed_subset _speed_category extra_args; do
+  [[ -z "$bname" ]] && continue
+  run_sglang_bench "$CONTAINER" "$PORT" "$WORKLOAD_MODEL" \
+                   "$bname" "$backend" "$dataset" "$isl" "$osl" "$nprompts" \
+                   "$conc" "$extra_args" "$RESULTS_DIR"
+
+  python3 "$DIR/ingest_perf.py" \
+    --raw-result "${RESULTS_DIR}/bench-${bname}.json" \
+    --framework sglang \
+    --device "$WORKLOAD_BENCH_DEVICE" \
+    --tp "$WORKLOAD_BENCH_TP" \
+    --precision "$WORKLOAD_BENCH_PRECISION" \
+    --model "$WORKLOAD_MODEL" \
+    --image "$WORKLOAD_IMAGE" \
+    --isl "$isl" --osl "$osl" --conc "$conc" || true
+done <<< "$WORKLOAD_SGLANG_BENCH_TSV"
 
 if [[ "${BENCH_ONLY:-}" =~ ^([Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss])$ ]]; then
   echo "--- :stopwatch: BENCH_ONLY set; skipping lm_eval and bfcl tasks"

--- a/lib/run_sglang_bench.sh
+++ b/lib/run_sglang_bench.sh
@@ -1,0 +1,90 @@
+# Run a single `python3 -m sglang.bench_serving` config against the running
+# SGLang server. Source this from run.sh after run_vllm_bench.sh so the shared
+# append_bench_args helper is available.
+#
+# Usage:
+#   run_sglang_bench <container> <port> <model> <name> <backend> <dataset> \
+#                    <input_len> <output_len> <num_prompts> <max_concurrency> \
+#                    <extra_args_base64> <output_dir>
+#
+# The raw JSONL lands in "<output_dir>/bench-<name>.jsonl"; the final appended
+# row is also copied to "<output_dir>/bench-<name>.json" for ingest_perf.py.
+
+run_sglang_bench() {
+  local container=$1 port=$2 model=$3 name=$4 backend=$5 dataset=$6
+  local input_len=$7 output_len=$8 num_prompts=$9 max_concurrency=${10}
+  local extra_args_base64=${11} outdir=${12}
+  local runtime="${WORKLOAD_SERVER_RUNTIME:-docker}"
+  local host_jsonl="${outdir}/bench-${name}.jsonl"
+  local host_json="${outdir}/bench-${name}.json"
+  local in_container_jsonl="/tmp/bench-${name}.jsonl"
+  local output_jsonl="$host_jsonl"
+
+  [[ "$backend" == "-" ]] && backend="sglang"
+
+  echo "--- :stopwatch: sglang bench_serving ${name} (dataset=${dataset} isl=${input_len} osl=${output_len} conc=${max_concurrency} n=${num_prompts})"
+  mkdir -p "$outdir"
+  rm -f "$host_jsonl" "$host_json"
+  if [[ "$runtime" != "native" ]]; then
+    output_jsonl="$in_container_jsonl"
+    docker exec "$container" rm -f "$in_container_jsonl" >/dev/null 2>&1 || true
+  fi
+
+  local cmd=(python3 -m sglang.bench_serving)
+  [[ "$runtime" != "native" ]] && cmd=(docker exec "$container" "${cmd[@]}")
+
+  cmd+=(
+    --backend "$backend"
+    --host 127.0.0.1
+    --port "$port"
+    --model "$model"
+    --dataset-name "$dataset"
+    --num-prompts "$num_prompts"
+    --max-concurrency "$max_concurrency"
+  )
+
+  case "$dataset" in
+    random)
+      cmd+=(
+        --random-input-len "$input_len"
+        --random-output-len "$output_len"
+        --random-range-ratio 1.0
+        --warmup-requests 64
+        --flush-cache
+      )
+      ;;
+    *)
+      echo "unsupported sglang_bench dataset: $dataset" >&2
+      return 2
+      ;;
+  esac
+
+  append_bench_args "$extra_args_base64" cmd
+  cmd+=(--output-file "$output_jsonl")
+
+  "${cmd[@]}"
+
+  [[ "$runtime" != "native" ]] && docker cp "${container}:${in_container_jsonl}" "$host_jsonl"
+
+  python3 - "$host_jsonl" "$host_json" "$num_prompts" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+jsonl_path, json_path, expected = sys.argv[1], sys.argv[2], int(sys.argv[3])
+lines = [line for line in Path(jsonl_path).read_text().splitlines() if line.strip()]
+if not lines:
+    print(f"sglang bench_serving produced no JSONL rows: {jsonl_path}", file=sys.stderr)
+    sys.exit(1)
+result = json.loads(lines[-1])
+completed = int(result.get("completed") or 0)
+if completed != expected:
+    print(
+        f"sglang bench_serving incomplete: completed={completed} expected={expected}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+Path(json_path).write_text(json.dumps(result) + "\n")
+PY
+  echo "  saved $host_json"
+}

--- a/lib/server.sh
+++ b/lib/server.sh
@@ -1,23 +1,23 @@
-# vLLM server lifecycle. Source this from run.sh.
+# Server lifecycle. Source this from run.sh.
 #
 # Functions:
-#   start_server <container> <port> <image> <model> <serve_args> <env> [runtime]
+#   start_server <container> <port> <image> <model> <serve_args> <env> [runtime] [engine]
 #   wait_healthy <port> [timeout_s=1500]
 #   stop_server  <container>
 #
 # `env` is a newline-separated list of KEY=VALUE pairs. For Docker runtime,
 # each value is injected into the container with -e. As a special case, HF_HOME
 # is also bind-mounted at the same path inside the container so the model cache
-# on the host is visible to vLLM. For native runtime, values are exported before
-# starting `vllm serve` in the current job container.
+# on the host is visible to the server. For native runtime, values are exported
+# before starting the server process in the current job container.
 #
-# After start_server, vLLM logs are streamed to stdout (prefixed with `[vllm]`)
-# so build output reflects server startup progress in real time. The streamer's
-# PID is held in $VLLM_LOGS_PID; stop_server kills it.
+# After start_server, logs are streamed to stdout so build output reflects
+# server startup progress in real time. The streamer's PID is held in
+# $VLLM_LOGS_PID; stop_server kills it.
 
 start_server() {
-  local container=$1 port=$2 image=$3 model=$4 serve_args=$5 env=$6 runtime=${7:-docker}
-  echo "--- :rocket: starting vllm: $model"
+  local container=$1 port=$2 image=$3 model=$4 serve_args=$5 env=$6 runtime=${7:-docker} engine=${8:-vllm}
+  echo "--- :rocket: starting ${engine}: $model"
 
   if [[ "$runtime" == "native" ]]; then
     while IFS= read -r kv; do
@@ -26,11 +26,24 @@ start_server() {
     done <<< "$env"
     local log_file="/tmp/${container}.log"
     VLLM_LOG_FILE="$log_file"
-    # shellcheck disable=SC2086  # serve_args intentionally word-split
-    vllm serve "$model" --port "$port" $serve_args >"$log_file" 2>&1 &
+    case "$engine" in
+      vllm)
+        # shellcheck disable=SC2086  # serve_args intentionally word-split
+        vllm serve "$model" --port "$port" $serve_args >"$log_file" 2>&1 &
+        ;;
+      sglang)
+        # shellcheck disable=SC2086  # serve_args intentionally word-split
+        python3 -m sglang.launch_server --model-path "$model" \
+          --host 0.0.0.0 --port "$port" $serve_args >"$log_file" 2>&1 &
+        ;;
+      *)
+        echo "unsupported server engine for native runtime: $engine" >&2
+        return 2
+        ;;
+    esac
     VLLM_SERVER_PID=$!
-    echo "--- :memo: streaming vllm logs"
-    ( tail -f "$log_file" 2>/dev/null | stdbuf -oL -eL sed 's/^/[vllm] /' ) &
+    echo "--- :memo: streaming ${engine} logs"
+    ( tail -f "$log_file" 2>/dev/null | stdbuf -oL -eL sed "s/^/[${engine}] /" ) &
     VLLM_LOGS_PID=$!
     return
   fi
@@ -48,18 +61,33 @@ start_server() {
     docker_args+=(-v "${hf_home}:${hf_home}")
   fi
 
-  # shellcheck disable=SC2086  # serve_args intentionally word-split
-  # vllm/vllm-openai's entrypoint takes the model as the first positional
-  # arg; do not prepend `vllm` or `serve`.
-  docker run -d --rm --name "$container" "${docker_args[@]}" \
-    "$image" \
-    "$model" --port "$port" $serve_args
+  case "$engine" in
+    vllm)
+      # shellcheck disable=SC2086  # serve_args intentionally word-split
+      # vllm/vllm-openai's entrypoint takes the model as the first positional
+      # arg; do not prepend `vllm` or `serve`.
+      docker run -d --rm --name "$container" "${docker_args[@]}" \
+        "$image" \
+        "$model" --port "$port" $serve_args
 
-  # Install pytest to avoid cupy.testing import failure during torch.compile
-  docker exec "$container" pip install -q pytest 2>/dev/null || true
+      # Install pytest to avoid cupy.testing import failure during torch.compile
+      docker exec "$container" pip install -q pytest 2>/dev/null || true
+      ;;
+    sglang)
+      # shellcheck disable=SC2086  # serve_args intentionally word-split
+      docker run -d --rm --name "$container" "${docker_args[@]}" \
+        "$image" \
+        python3 -m sglang.launch_server --model-path "$model" \
+          --host 0.0.0.0 --port "$port" $serve_args
+      ;;
+    *)
+      echo "unsupported server engine for docker runtime: $engine" >&2
+      return 2
+      ;;
+  esac
 
-  echo "--- :memo: streaming vllm logs"
-  ( docker logs -f "$container" 2>&1 | stdbuf -oL -eL sed 's/^/[vllm] /' ) &
+  echo "--- :memo: streaming ${engine} logs"
+  ( docker logs -f "$container" 2>&1 | stdbuf -oL -eL sed "s/^/[${engine}] /" ) &
   VLLM_LOGS_PID=$!
 }
 
@@ -76,7 +104,7 @@ wait_healthy() {
       return 0
     fi
     if [[ -n "${VLLM_SERVER_PID:-}" ]] && ! kill -0 "$VLLM_SERVER_PID" 2>/dev/null; then
-      echo "vLLM server exited before becoming healthy" >&2
+      echo "server exited before becoming healthy" >&2
       [[ -n "${VLLM_LOG_FILE:-}" ]] && tail -n 80 "$VLLM_LOG_FILE" >&2 || true
       return 1
     fi

--- a/workloads/b300_runner_smoke.yaml
+++ b/workloads/b300_runner_smoke.yaml
@@ -8,12 +8,15 @@ nightly: false
 bench_only: true
 
 vllm:
-  model: facebook/opt-125m
+  # Use a tokenizer without OPT's implicit BOS token. The benchmarker's exact
+  # length correction can otherwise reduce very short random prompts to empty.
+  model: Qwen/Qwen2.5-0.5B-Instruct
   image: vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519
   startup_timeout: 900
   serve_args: >-
     --max-model-len 2048
     --gpu-memory-utilization 0.10
+    --enforce-eager
 
 vllm_bench:
   configs:

--- a/workloads/b300_runner_smoke.yaml
+++ b/workloads/b300_runner_smoke.yaml
@@ -1,0 +1,26 @@
+# Opt-in end-to-end smoke for the standalone Axis B300 Buildkite agent and its
+# Docker plugin. This intentionally uses a tiny public model and four requests.
+name: b300-runner-smoke
+gpu: B300
+num_gpus: 1
+timeout_in_minutes: 30
+nightly: false
+bench_only: true
+
+vllm:
+  model: facebook/opt-125m
+  image: vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519
+  startup_timeout: 900
+  serve_args: >-
+    --max-model-len 2048
+    --gpu-memory-utilization 0.10
+
+vllm_bench:
+  configs:
+    - name: tiny-random-16
+      backend: openai
+      dataset: random
+      input_len: 16
+      output_len: 16
+      num_prompts: 4
+      max_concurrency: 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -1,0 +1,48 @@
+# GLM-5.2 FP8 on B200 with SGLang
+# Recipe: https://lmsysorg.mintlify.app/cookbook/autoregressive/GLM/GLM-5.2#hw=b200&variant=default&quant=fp8&strategy=balanced&nodes=single
+name: glm_5_2-sglang-b200
+gpu: B200
+num_gpus: 8
+timeout_in_minutes: 180
+bench_only: true
+
+sglang:
+  model: zai-org/GLM-5.2-FP8
+  image: lmsysorg/sglang:latest
+  env:
+    SGLANG_SIMULATE_ACC_LEN: 2
+  serve_args: >-
+    --tp 8
+    --dp 8
+    --enable-dp-attention
+    --moe-a2a-backend deepep
+    --speculative-algorithm EAGLE
+    --speculative-num-steps 1
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 2
+    --mem-fraction-static 0.85
+    --chunked-prefill-size 32768
+    --max-running-requests 256
+
+sglang_bench:
+  metadata:
+    device: b200
+    # SGLang's GLM-5.2 B200 balanced recipe is one 8-GPU node. Do not use
+    # tp*dp here: --dp 8 is part of DP-attention, not 64 physical GPUs.
+    tp: 8
+    precision: fp8
+  configs:
+    - name: 8k-in-1k-out-conc-64
+      backend: sglang
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 128
+      max_concurrency: 64
+    - name: 8k-in-1k-out-conc-256
+      backend: sglang
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 256

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -1,19 +1,22 @@
-# GLM-5.2 FP8 on B200 with SGLang
+# GLM-5.2 FP8 recipe migrated to one standalone 8xB300 with SGLang.
 # Recipe: https://lmsysorg.mintlify.app/cookbook/autoregressive/GLM/GLM-5.2#hw=b200&variant=default&quant=fp8&strategy=balanced&nodes=single
 # The published B200 balanced result is measured on SGLang main @ 09ca4fc with
 # lmsysorg/sglang:latest, DP8 + DeepEP, SGLANG_SIMULATE_ACC_LEN=2, and the
 # 8K/1K concurrency-64/256 benchmark cells below.
-name: glm_5_2-sglang-b200-deepep
-gpu: B200
+name: glm_5_2-sglang-b300-deepep
+gpu: B300
 num_gpus: 8
 timeout_in_minutes: 180
 bench_only: true
 
 sglang:
-  model: zai-org/GLM-5.2-FP8
+  # Pre-staged on the standalone Axis host; avoids a second 700+ GB download.
+  model: /raid/inf-simon/models/zai-org/GLM-5.2-FP8
   image: lmsysorg/sglang:latest
   env:
     SGLANG_SIMULATE_ACC_LEN: 2
+    # Single-node DeepEP should stay on NVLink on this host.
+    NVSHMEM_DISABLE_IB: 1
   serve_args: >-
     --tp 8
     --dp 8
@@ -29,7 +32,7 @@ sglang:
 
 sglang_bench:
   metadata:
-    device: b200
+    device: b300
     # SGLang's GLM-5.2 B200 balanced recipe is one 8-GPU node. Do not use
     # tp*dp here: --dp 8 is part of DP-attention, not 64 physical GPUs.
     tp: 8

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -1,6 +1,9 @@
 # GLM-5.2 FP8 on B200 with SGLang
 # Recipe: https://lmsysorg.mintlify.app/cookbook/autoregressive/GLM/GLM-5.2#hw=b200&variant=default&quant=fp8&strategy=balanced&nodes=single
-name: glm_5_2-sglang-b200
+# The recipe's balanced strategy uses DeepEP. The current B200 Kubernetes pod
+# does not expose a working NVSHMEM/IBGDA path, so this CI baseline uses the
+# SGLang `none` A2A backend (All-Reduce/All-Gather token dispatch) instead.
+name: glm_5_2-sglang-b200-nodeepep
 gpu: B200
 num_gpus: 8
 timeout_in_minutes: 180
@@ -15,7 +18,7 @@ sglang:
     --tp 8
     --dp 8
     --enable-dp-attention
-    --moe-a2a-backend deepep
+    --moe-a2a-backend none
     --speculative-algorithm EAGLE
     --speculative-num-steps 1
     --speculative-eagle-topk 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -1,9 +1,9 @@
 # GLM-5.2 FP8 on B200 with SGLang
 # Recipe: https://lmsysorg.mintlify.app/cookbook/autoregressive/GLM/GLM-5.2#hw=b200&variant=default&quant=fp8&strategy=balanced&nodes=single
-# The recipe's balanced strategy uses DeepEP. The current B200 Kubernetes pod
-# does not expose a working NVSHMEM/IBGDA path, so this CI baseline uses the
-# SGLang `none` A2A backend (All-Reduce/All-Gather token dispatch) instead.
-name: glm_5_2-sglang-b200-nodeepep
+# The published B200 balanced result is measured on SGLang main @ 09ca4fc with
+# lmsysorg/sglang:latest, DP8 + DeepEP, SGLANG_SIMULATE_ACC_LEN=2, and the
+# 8K/1K concurrency-64/256 benchmark cells below.
+name: glm_5_2-sglang-b200-deepep
 gpu: B200
 num_gpus: 8
 timeout_in_minutes: 180
@@ -18,7 +18,7 @@ sglang:
     --tp 8
     --dp 8
     --enable-dp-attention
-    --moe-a2a-backend none
+    --moe-a2a-backend deepep
     --speculative-algorithm EAGLE
     --speculative-num-steps 1
     --speculative-eagle-topk 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -20,6 +20,7 @@ sglang:
     --dp 8
     --enable-dp-attention
     --moe-a2a-backend flashinfer
+    --moe-runner-backend flashinfer_cutlass
     --kv-cache-dtype fp8_e4m3
     --speculative-algorithm EAGLE
     --speculative-num-steps 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -13,13 +13,13 @@ sglang:
   model: /raid/inf-simon/models/zai-org/GLM-5.2-FP8
   image: lmsysorg/sglang:latest
   env:
-    # Single-node DeepEP should stay on NVLink on this host.
+    # Keep the standalone node on its NVLink-local transport path.
     NVSHMEM_DISABLE_IB: 1
   serve_args: >-
     --tp 8
     --dp 8
     --enable-dp-attention
-    --moe-a2a-backend deepep
+    --moe-a2a-backend flashinfer
     --kv-cache-dtype fp8_e4m3
     --speculative-algorithm EAGLE
     --speculative-num-steps 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -1,9 +1,8 @@
-# GLM-5.2 FP8 recipe migrated to one standalone 8xB300 with SGLang.
-# Recipe: https://lmsysorg.mintlify.app/cookbook/autoregressive/GLM/GLM-5.2#hw=b200&variant=default&quant=fp8&strategy=balanced&nodes=single
-# The published B200 balanced result is measured on SGLang main @ 09ca4fc with
-# lmsysorg/sglang:latest, DP8 + DeepEP, SGLANG_SIMULATE_ACC_LEN=2, and the
-# 8K/1K concurrency-64/256 benchmark cells below.
-name: glm_5_2-sglang-b300-deepep
+# GLM-5.2 FP8 apples-to-apples SGLang recipe on one standalone 8xB300.
+# This uses real EAGLE acceptance. Topology, transport, memory/cache policy,
+# context/prefill limits, client shape, and speculative depth are aligned with
+# glm_5_2_b200.yaml.
+name: glm_5_2-b300-apples-sglang
 gpu: B300
 num_gpus: 8
 timeout_in_minutes: 180
@@ -14,7 +13,6 @@ sglang:
   model: /raid/inf-simon/models/zai-org/GLM-5.2-FP8
   image: lmsysorg/sglang:latest
   env:
-    SGLANG_SIMULATE_ACC_LEN: 2
     # Single-node DeepEP should stay on NVLink on this host.
     NVSHMEM_DISABLE_IB: 1
   serve_args: >-
@@ -22,13 +20,17 @@ sglang:
     --dp 8
     --enable-dp-attention
     --moe-a2a-backend deepep
+    --kv-cache-dtype fp8_e4m3
     --speculative-algorithm EAGLE
     --speculative-num-steps 1
     --speculative-eagle-topk 1
     --speculative-num-draft-tokens 2
     --mem-fraction-static 0.85
+    --context-length 32768
     --chunked-prefill-size 32768
+    --max-prefill-tokens 32768
     --max-running-requests 256
+    --disable-radix-cache
 
 sglang_bench:
   metadata:

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -20,6 +20,7 @@ sglang:
     --dp 8
     --enable-dp-attention
     --moe-a2a-backend none
+    --moe-runner-backend deep_gemm
     --kv-cache-dtype fp8_e4m3
     --speculative-algorithm EAGLE
     --speculative-num-steps 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -20,7 +20,7 @@ sglang:
     --dp 8
     --enable-dp-attention
     --moe-a2a-backend none
-    --moe-runner-backend deep_gemm
+    --moe-runner-backend triton
     --kv-cache-dtype fp8_e4m3
     --speculative-algorithm EAGLE
     --speculative-num-steps 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -19,8 +19,7 @@ sglang:
     --tp 8
     --dp 8
     --enable-dp-attention
-    --moe-a2a-backend flashinfer
-    --moe-runner-backend flashinfer_cutlass
+    --moe-a2a-backend none
     --kv-cache-dtype fp8_e4m3
     --speculative-algorithm EAGLE
     --speculative-num-steps 1

--- a/workloads/glm_5_2_sglang_b200.yaml
+++ b/workloads/glm_5_2_sglang_b200.yaml
@@ -18,6 +18,7 @@ sglang:
   serve_args: >-
     --tp 8
     --dp 8
+    --ep-size 8
     --enable-dp-attention
     --moe-a2a-backend none
     --moe-runner-backend triton


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary

- Migrates the opt-in GLM-5.2 FP8 SGLang baseline from the shared B200 Kubernetes pool to the standalone Axis 8×B300 runner.
- Adds a first-class `B300` perf-eval profile on Buildkite queue `b300-8` using `docker#v5.2.0`.
- Runs the SGLang image as the Buildkite agent UID/GID with all GPUs, host networking/IPC, memlock/stack ulimits, and `/raid` mounted.
- Exposes the Buildkite agent identity through read-only passwd/group mounts and overlays a persistent writable FlashInfer cubin cache into the image package path.
- Reuses the staged checkpoint at `/raid/inf-simon/models/zai-org/GLM-5.2-FP8`.
- Keeps single-node DeepEP on NVLink with `NVSHMEM_DISABLE_IB=1`.
- Preserves the SGLang DP8/DP-attention/DeepEP/EAGLE recipe and 8K-input/1K-output concurrency 64/256 cells.

## Buildkite

Runner: `dgxB300-01-1`  
Queue: `b300-8`

Validated runs:

- [#372 repeat-safe B300 smoke](https://buildkite.com/vllm/perf-eval/builds/372): passed, 4/4 requests; container ran as UID/GID 996:986 and left no GPU processes or foreign-owned checkout files.
- [#378 GLM-5.2 SGLang](https://buildkite.com/vllm/perf-eval/builds/378): passed and ingested.
  - C64, 128/128: 2,841.12 output tok/s; 25,570.09 total tok/s; 3,196.26 total tok/s/GPU; mean TTFT 5.6865 s; mean TPOT 16.97 ms.
  - C256, 512/512: 5,074.58 output tok/s; 45,671.22 total tok/s; 5,708.90 total tok/s/GPU; mean TTFT 13.3024 s; mean TPOT 33.34 ms.
  - The migrated recipe intentionally uses simulated EAGLE acceptance; server logs show accept length 2.00 and acceptance rate 1.00.

Invocation:

```text
WORKLOADS=glm_5_2_sglang_b200
SGLANG_IMAGE=lmsysorg/sglang:latest
```

The workload filename remains stable for existing invocations; its rendered name/device are B300.

## Validation

- `python .buildkite/test_generate_pipeline.py` — 12/12 passed
- B300 smoke and GLM pipeline generation emit queue `b300-8` plus `docker#v5.2.0`
- SGLang workload parser emits the B300 model path and NVLink-only DeepEP env
- Arbitrary-UID identity and both writable cubin overlays validated against the exact runtime images
- `bash -n lib/*.sh`
- Python compile checks for generator/parser/ingest paths
- `git diff --check`
