### PR TITLE
Use system CUDA for DeepSeek V4 Flash JIT

### DIFF
--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -6,6 +6,10 @@ nightly: true
 
 vllm:
   model: deepseek-ai/DeepSeek-V4-Flash
+  env:
+    # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
+    CUDA_HOME: /usr/local/cuda
+    TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
   serve_args: >-
     --tensor-parallel-size 2
     --data-parallel-size 4


### PR DESCRIPTION
## Summary

- set `CUDA_HOME=/usr/local/cuda` for the DeepSeek V4 Flash B200 workload
- set `TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas` so Triton follows the same toolkit
- leave the workload topology, model arguments, and evaluation coverage unchanged

## Root cause

The original DeepSeek V4 Flash attempt in [nightly build 333](https://buildkite.com/vllm/perf-eval/builds/333#019faa96-8cdc-4e1e-a764-896cde0a3079) selected `/usr/local/lib/python3.12/dist-packages/nvidia/cu13/bin/nvcc` for TileLang JIT compilation. CCCL then rejected the compiler/header combination with:

`CUDA compiler and CUDA toolkit headers are incompatible`

Selecting the image's system CUDA installation keeps the compiler, headers, and PTX assembler on one matched toolkit. This is the same system-toolkit fix already validated for the DeepSeek V4 Pro B200 workload.

## Impact

DeepSeek V4 Flash can proceed past TileLang kernel compilation instead of exiting before the server becomes healthy.

## Validation

- [Targeted Buildkite build 352](https://buildkite.com/vllm/perf-eval/builds/352) passed the full `deepseek_v4_flash-b200` job, including all previously failing TileLang JIT kernels and server startup
- build 352 exercised the identical code diff; the branch was subsequently amended only to add the DCO sign-off
- `BENCH_ONLY=1 python3 lib/parse_workload.py workloads/deepseek_v4_flash_b200.yaml`
- confirmed both toolkit variables are present in `WORKLOAD_ENV`
- `python3 .buildkite/test_generate_pipeline.py` (6/6)
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `git diff --check`