### PR TITLE
Keep Qwen3.5 benchmark within stable prompt set

### DIFF
--- a/workloads/qwen3_5_h200.yaml
+++ b/workloads/qwen3_5_h200.yaml
@@ -34,7 +34,5 @@ vllm_bench:
       dataset: random
       input_len: 8192
       output_len: 1024
-      num_prompts: 512
+      num_prompts: 256
       max_concurrency: 128
-      args:
-        prompt_token_ids: true

--- a/workloads/qwen3_5_h200.yaml
+++ b/workloads/qwen3_5_h200.yaml
@@ -36,3 +36,5 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      args:
+        prompt_token_ids: true


### PR DESCRIPTION
## Summary

- run the Qwen3.5 H200 random serving benchmark with 256 prompts at concurrency 128
- preserve the existing 8K input and 1K output lengths
- retain two fully saturated benchmark waves while excluding the unstable generated sample

## Root cause

The Qwen3.5 H200 server in [nightly build 333](https://buildkite.com/vllm/perf-eval/builds/333#019faa96-8cf2-48b7-b897-9e18922685f1) started successfully, but the Rust random-dataset client failed before inference at prompt 451:

`Tokenizer error: Prompt 451: server verification failed to converge after 20 iterations`

The first attempted workaround sent generated token IDs directly. [Targeted build 353](https://buildkite.com/vllm/perf-eval/builds/353) proved that the pinned `d223c900` image does not expose that newer CLI option:

`vllm: error: unrecognized arguments: --prompt-token-ids`

Using 256 prompts matches the compatible workaround already validated by the Qwen3.5 B200 workload: it preserves two waves at concurrency 128 while staying below the generated sample that cannot round-trip between client and server tokenizers.

## Impact

The serving benchmark reaches inference on the pinned nightly image without weakening the input/output lengths or concurrency coverage.

## Validation

- [Targeted Buildkite build 355](https://buildkite.com/vllm/perf-eval/builds/355) passed the full Qwen3.5 H200 `BENCH_ONLY` workload on commit `91b1167`
- serving benchmark completed 256/256 requests with zero failures at concurrency 128; results were saved, uploaded, and ingested successfully
- `BENCH_ONLY=1 python3 lib/parse_workload.py workloads/qwen3_5_h200.yaml`
- confirmed the parsed benchmark is `n=256`, concurrency 128, with no extra CLI args
- `python3 .buildkite/test_generate_pipeline.py` (6/6)
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `git diff --check`