### PR TITLE
Harden pipeline dependency downloads

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -26,17 +26,19 @@ import sys
 import yaml
 
 def setup_command(packages):
+    pip_network_args = "--retries 10 --timeout 120"
     return (
         "if python3 -m venv .venv; then\n"
         "  . .venv/bin/activate\n"
         "  (python -m ensurepip --upgrade --default-pip 2>/dev/null"
         " || curl -fsSL https://bootstrap.pypa.io/get-pip.py | python)\n"
-        f"  python -m pip install --upgrade {packages}\n"
+        f"  python -m pip install --upgrade {pip_network_args} {packages}\n"
         "else\n"
         "  rm -rf .venv\n"
         "  (python3 -m ensurepip --user --upgrade --default-pip 2>/dev/null"
         " || curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --user)\n"
-        f"  PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user --upgrade {packages}\n"
+        "  PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user --upgrade"
+        f" {pip_network_args} {packages}\n"
         "fi"
     )
 

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -100,6 +100,11 @@ def test_shipped_amd_profiles_have_no_rootdisk_hostpath():
         )
 
 
+def test_setup_command_tolerates_slow_package_downloads():
+    command = g.setup_command("pyyaml")
+    assert command.count("--retries 10 --timeout 120") == 2, command
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
## Summary

- give generated pip installs 10 connection retries
- raise pip's network timeout to 120 seconds
- cover both the virtualenv path and the system/user fallback path
- add a regression test for the generated setup command

## Root cause

The original GPT-OSS 120B B200 attempt in [nightly build 333](https://buildkite.com/vllm/perf-eval/builds/333#019faa96-8cec-4680-9019-44ef414f0b7d) never reached the workload. Its bootstrap download from `files.pythonhosted.org` stalled mid-wheel and pip exited with `ReadTimeoutError`.

Every generated job installs the evaluation dependencies before starting vLLM, so the default short read timeout makes otherwise healthy GPU jobs vulnerable to transient package-host latency.

## Impact

Slow or briefly interrupted package downloads get substantially more time and retries before consuming a GPU job as a bootstrap failure.

## Validation

- `python3 .buildkite/test_generate_pipeline.py` (7/7)
- `python3 -m py_compile .buildkite/generate_pipeline.py .buildkite/test_generate_pipeline.py`
- generated the GPT-OSS B200 step and confirmed both pip paths include `--retries 10 --timeout 120`
- `git diff --check`