### PR TITLE
Add `PERF_INGEST_TOKEN` Requirement To Post Perf Data to DB

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -142,6 +142,16 @@ def b200_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                                     },
                                 },
                             },
+                            {
+                                "name": "PERF_INGEST_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "perf-ingest-token",
+                                        "key": "token",
+                                        "optional": True,
+                                    },
+                                },
+                            },
                         ],
                     },
                 ],
@@ -212,6 +222,16 @@ def amd_k8s_plugin(image, num_gpus, profile=None, gpu=None):
                                     "secretKeyRef": {
                                         "name": "hf-token",
                                         "key": "TOKEN",
+                                    },
+                                },
+                            },
+                            {
+                                "name": "PERF_INGEST_TOKEN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "perf-ingest-token",
+                                        "key": "token",
+                                        "optional": True,
                                     },
                                 },
                             },

--- a/lib/ingest.py
+++ b/lib/ingest.py
@@ -49,10 +49,14 @@ NIGHTLY_ENV = "NIGHTLY"
 
 def post(endpoint: str, payload: dict) -> None:
     body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("PERF_INGEST_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(
         endpoint,
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:

--- a/lib/ingest_perf.py
+++ b/lib/ingest_perf.py
@@ -30,10 +30,14 @@ TIMEOUT = 30
 
 def post(endpoint: str, payload: dict) -> None:
     body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json", "X-Source": "perf-eval"}
+    token = os.environ.get("PERF_INGEST_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(
         endpoint,
         data=body,
-        headers={"Content-Type": "application/json", "X-Source": "perf-eval"},
+        headers=headers,
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:


### PR DESCRIPTION
Authenticate so only the official BK pipeline (which holds the shared secret) can post to the perf dashboard's ingestion endpoint. Off-pipeline runs without the token get rejected by the ingest service. Ingestion is best-effort so any runs that get rejected due to lack of a valid token will still continue to run to completion. 