### PR TITLE
Avoid native server port collisions

### DIFF
--- a/.buildkite/test_server_lifecycle.py
+++ b/.buildkite/test_server_lifecycle.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Stdlib-only regression tests for the shell server lifecycle helpers."""
+
+import hashlib
+import http.server
+import json
+import os
+import socket
+import subprocess
+import threading
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SERVER_SH = os.path.join(ROOT, "lib", "server.sh")
+
+
+def run_bash(command, *, env=None, timeout=10):
+    return subprocess.run(
+        ["bash", "-c", f"source {SERVER_SH!r}; {command}"],
+        env={**os.environ, **(env or {})},
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def first_port(seed):
+    digest = hashlib.sha256(seed.encode()).digest()
+    return 20000 + int.from_bytes(digest[:4], "big") % 40000
+
+
+def test_job_ids_get_distinct_stable_ports():
+    first = run_bash("pick_server_port", env={"BUILDKITE_JOB_ID": "job-a"})
+    again = run_bash("pick_server_port", env={"BUILDKITE_JOB_ID": "job-a"})
+    second = run_bash("pick_server_port", env={"BUILDKITE_JOB_ID": "job-b"})
+    assert first.returncode == again.returncode == second.returncode == 0
+    assert first.stdout == again.stdout
+    assert first.stdout != second.stdout
+
+
+def test_port_picker_skips_a_port_already_in_use():
+    seed = "occupied-port"
+    occupied = first_port(seed)
+    with socket.socket() as sock:
+        sock.bind(("0.0.0.0", occupied))
+        result = run_bash("pick_server_port", env={"BUILDKITE_JOB_ID": seed})
+    assert result.returncode == 0, result.stderr
+    assert int(result.stdout) != occupied
+
+
+def test_health_check_verifies_the_served_model():
+    expected_model = "org/expected-model"
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                body = b""
+            elif self.path == "/v1/models":
+                body = json.dumps({"data": [{"id": expected_model}]}).encode()
+            else:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        match = run_bash(f"server_is_healthy {port} org/expected-model")
+        mismatch = run_bash(f"server_is_healthy {port} org/other-model")
+    finally:
+        server.shutdown()
+        thread.join()
+    assert match.returncode == 0, match.stderr
+    assert mismatch.returncode != 0
+
+
+def test_stop_process_is_bounded_when_term_is_ignored():
+    started = time.monotonic()
+    result = run_bash(
+        "bash -c 'trap \"\" TERM; while :; do sleep 1; done' & "
+        "pid=$!; sleep 0.1; stop_process \"$pid\" 1",
+        timeout=4,
+    )
+    assert result.returncode == 0, result.stderr
+    assert time.monotonic() - started < 3
+
+
+def main():
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"ok   {test.__name__}")
+        except (AssertionError, subprocess.TimeoutExpired) as exc:
+            failed += 1
+            print(f"FAIL {test.__name__}: {exc}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -19,7 +19,7 @@ WORKLOAD_EXPORTS="$(python3 "$DIR/parse_workload.py" "$WORKLOAD")"
 eval "$WORKLOAD_EXPORTS"
 export WORKLOAD_IMAGE WORKLOAD_VLLM_COMMIT WORKLOAD_SERVER_RUNTIME
 
-PORT=8000
+PORT="${PERF_EVAL_SERVER_PORT:-$(pick_server_port)}"
 CONTAINER="perf-eval-${WORKLOAD_NAME}-$$"
 RESULTS_DIR="results/${WORKLOAD_NAME}"
 BASE_URL="http://localhost:${PORT}"
@@ -34,7 +34,7 @@ trap 'stop_server "$CONTAINER"' EXIT
 
 start_server "$CONTAINER" "$PORT" "$WORKLOAD_IMAGE" "$WORKLOAD_MODEL" \
              "$WORKLOAD_SERVE_ARGS" "$WORKLOAD_ENV" "$WORKLOAD_SERVER_RUNTIME"
-wait_healthy "$PORT"
+wait_healthy "$PORT" 3600 "$WORKLOAD_MODEL"
 
 # vllm bench serve runs first so we can validate perf flow without waiting
 # on a full lm_eval pass. Each config's raw json lands in

--- a/lib/server.sh
+++ b/lib/server.sh
@@ -1,8 +1,10 @@
+# shellcheck shell=bash
 # vLLM server lifecycle. Source this from run.sh.
 #
 # Functions:
+#   pick_server_port
 #   start_server <container> <port> <image> <model> <serve_args> <env> [runtime]
-#   wait_healthy <port> [timeout_s=1500]
+#   wait_healthy <port> [timeout_s=3600] [expected_model]
 #   stop_server  <container>
 #
 # `env` is a newline-separated list of KEY=VALUE pairs. For Docker runtime,
@@ -15,6 +17,32 @@
 # so build output reflects server startup progress in real time. The streamer's
 # PID is held in $VLLM_LOGS_PID; stop_server kills it.
 
+pick_server_port() {
+  # Native GPU jobs use host networking and multiple jobs can share a node.
+  # Derive a stable high port from the Buildkite job ID so one job cannot
+  # mistake another job's vLLM server on port 8000 for its own.
+  local seed=${BUILDKITE_JOB_ID:-${HOSTNAME:-local}-$$}
+  python3 - "$seed" <<'PY'
+import hashlib
+import socket
+import sys
+
+seed = sys.argv[1].encode()
+first = 20000 + int.from_bytes(hashlib.sha256(seed).digest()[:4], "big") % 40000
+for offset in range(40000):
+    port = 20000 + (first - 20000 + offset) % 40000
+    with socket.socket() as sock:
+        try:
+            sock.bind(("0.0.0.0", port))
+        except OSError:
+            continue
+    print(port)
+    break
+else:
+    raise SystemExit("no free server port in 20000-59999")
+PY
+}
+
 start_server() {
   local container=$1 port=$2 image=$3 model=$4 serve_args=$5 env=$6 runtime=${7:-docker}
   echo "--- :rocket: starting vllm: $model"
@@ -22,6 +50,7 @@ start_server() {
   if [[ "$runtime" == "native" ]]; then
     while IFS= read -r kv; do
       [[ -z "$kv" ]] && continue
+      # shellcheck disable=SC2163  # kv is an intentional KEY=VALUE assignment
       export "$kv"
     done <<< "$env"
     local log_file="/tmp/${container}.log"
@@ -63,15 +92,30 @@ start_server() {
   VLLM_LOGS_PID=$!
 }
 
+server_is_healthy() {
+  local port=$1 expected_model=${2:-}
+  curl -fs "http://localhost:${port}/health" >/dev/null 2>&1 || return 1
+  [[ -z "$expected_model" ]] && return 0
+  curl -fs "http://localhost:${port}/v1/models" 2>/dev/null |
+    python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+models = json.load(sys.stdin).get("data", [])
+raise SystemExit(0 if any(model.get("id") == expected for model in models) else 1)
+' "$expected_model" 2>/dev/null
+}
+
 wait_healthy() {
-  local port=$1 timeout=${2:-3600}
+  local port=$1 timeout=${2:-3600} expected_model=${3:-}
   echo "+++ :hourglass: waiting for /health (timeout ${timeout}s)"
   local now start deadline next_status elapsed
   start=$(date +%s)
   deadline=$(( start + timeout ))
   next_status=$(( start + 60 ))
   while (( $(date +%s) < deadline )); do
-    if curl -fs "http://localhost:${port}/health" >/dev/null 2>&1; then
+    if server_is_healthy "$port" "$expected_model"; then
       echo "server healthy"
       return 0
     fi
@@ -92,15 +136,26 @@ wait_healthy() {
   return 1
 }
 
+stop_process() {
+  local pid=${1:-} timeout=${2:-10}
+  [[ -z "$pid" ]] && return 0
+  kill "$pid" 2>/dev/null || true
+  local start=$SECONDS
+  while kill -0 "$pid" 2>/dev/null && (( SECONDS - start < timeout )); do
+    sleep 0.1
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  wait "$pid" 2>/dev/null || true
+}
+
 stop_server() {
   local container=$1
-  if [[ -n "${VLLM_LOGS_PID:-}" ]]; then
-    kill "$VLLM_LOGS_PID" 2>/dev/null || true
-    wait "$VLLM_LOGS_PID" 2>/dev/null || true
-  fi
-  if [[ -n "${VLLM_SERVER_PID:-}" ]]; then
-    kill "$VLLM_SERVER_PID" 2>/dev/null || true
-    wait "$VLLM_SERVER_PID" 2>/dev/null || true
-  fi
+  # Stop the server/container before its log follower. If the follower's
+  # pipeline does not propagate TERM, stop_process escalates after a bounded
+  # wait instead of hanging the job until Buildkite's timeout.
+  stop_process "${VLLM_SERVER_PID:-}"
   docker rm -f "$container" >/dev/null 2>&1 || true
+  stop_process "${VLLM_LOGS_PID:-}"
 }


### PR DESCRIPTION
## What changed

- derive a high per-job server port from `BUILDKITE_JOB_ID`, skipping ports already in use
- require `/v1/models` to report the expected workload model before declaring the server healthy
- bound server and log-follower shutdown so a failed benchmark cannot hang until the Buildkite timeout
- add stdlib-only lifecycle regression tests for port selection, model-aware readiness, and cleanup escalation

## Root cause

In nightly build 350, `gpt_oss_120b-b200` and `minimax_m3-b200` ran concurrently on `dgxB200-14` with native servers using host networking and fixed port 8000. GPT-OSS became healthy at 06:12:31; three seconds later MiniMax's readiness probe accepted that server while MiniMax was still loading. MiniMax sent 512 requests for `nvidia/MiniMax-M3-NVFP4` to the GPT-OSS server and received 512 HTTP 404 responses. Its EXIT cleanup then blocked on the log-follower pipeline until the two-hour job timeout.

Build: https://buildkite.com/vllm/perf-eval/builds/350

## Validation

- `python3 .buildkite/test_server_lifecycle.py` (4/4)
- `python3 .buildkite/test_generate_pipeline.py` (6/6)
- `python3 -m py_compile .buildkite/test_server_lifecycle.py .buildkite/generate_pipeline.py lib/parse_workload.py`
- `bash -n lib/server.sh lib/run.sh lib/run_vllm_bench.sh`
- `shellcheck lib/server.sh lib/run.sh`
- MiniMax B200 workload parsing and targeted pipeline generation with `BENCH_ONLY=1`
- `git diff --check`
- Targeted B200 validation: https://buildkite.com/vllm/perf-eval/builds/357 — 512/512 successful requests, 0 failed