### PR TITLE
feat: Add ability to run `aiperf` + Kimi K3 MI355X `aiperf` workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ GPU allocation; use at most 8 GPUs to keep the workload on one B200 node.
 
 ### Recipe schema
 
-A recipe has top-level metadata plus up to three eval blocks:
+A recipe has top-level metadata plus up to four eval blocks:
 
 - **`vllm:`** — *how the server runs.* Defines what model to serve and how (`model`, `serve_args`, optional image/env overrides). Required.
 - **`lm_eval:`** — *what accuracy to measure.* Lists lm-evaluation-harness tasks to run against the live server (e.g. `gsm8k`, `aime25`). Each task's score is saved under `results/<name>/<task-name>/`. Optional.
 - **`vllm_bench:`** — *what perf to measure.* Lists `vllm bench serve` configs (input/output lengths, concurrency, dataset). Raw JSON is saved and ingested into the perf dashboard. Optional.
+- **`aiperf:`** — *what perf to measure with [aiperf](https://pypi.org/project/aiperf/).* Lists `aiperf profile` configs for scenarios `vllm bench serve` doesn't cover (e.g. prefix-cache sweeps, server-side token counting). aiperf is pip-installed at run time because the vLLM images don't ship it. Artifacts are saved under `results/<name>/aiperf-<config>/` and uploaded as Buildkite artifacts; there is no dashboard ingest yet. Optional.
 - **`bfcl:`** — *function-calling eval.* Runs [BFCL](https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard) test categories against the live server. Some models need `--enable-auto-tool-choice` and `--tool-call-parser` in `serve_args`. Results are transformed to lm_eval format and ingested as `bfcl_<category>` tasks. Optional.
 
-Include one or more of `lm_eval:` / `vllm_bench:` / `bfcl:` depending on what you want out of this recipe.
+Include one or more of `lm_eval:` / `vllm_bench:` / `aiperf:` / `bfcl:` depending on what you want out of this recipe.
 
 ```yaml
 name: qwen3_5-h200       # used in container name and results/<name>/
@@ -87,6 +88,18 @@ vllm_bench:              # perf runs (optional) — fed to the perf dashboard
       args:                             # optional vllm bench serve arguments
         num_warmups: 16                 # becomes --num-warmups 16
         disable_tqdm: true              # becomes --disable-tqdm
+
+aiperf:                 # perf runs via the aiperf CLI (optional)
+  configs:
+    - name: prefix63k-in4760-out350-conc16-24
+      args:                             # everything except model/tokenizer/url/api-key/output-artifact-dir
+        endpoint-type: chat             # becomes --endpoint-type chat
+        streaming: true                 # becomes --streaming
+        concurrency: "16,24"            # comma lists stay strings: --concurrency 16,24
+        request-count: "80,120"
+        extra-inputs:                   # a list repeats the flag
+          - "ignore_eos:true"           # --extra-inputs ignore_eos:true
+          - "max_tokens:350"
 ```
 
 A few things worth knowing:
@@ -97,6 +110,7 @@ A few things worth knowing:
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
 - **`vllm_bench` uses the `random` dataset with `--ignore-eos`** so every request prefills exactly `input_len` and decodes exactly `output_len` tokens — that's what makes the per-GPU decode throughput meaningful. Pair it with `backend: openai` (the `/v1/completions` endpoint) for exact token control. Avoid `dataset: speed_bench` for throughput numbers: it requires `--skip-tokenizer-init`, which makes `vllm bench serve` cap every request at a single output token, so output throughput reads as ~0.
 - **`vllm_bench.configs[].args` forwards additional options to `vllm bench serve`.** Keys may use underscores, hyphens, or a leading `--`; they are normalized to `--kebab-case`. A `true` value emits a standalone flag, `false` and `null` omit it, scalar values emit a flag/value pair, and lists repeat the flag. Options managed by perf-eval itself, including the model, endpoint, dataset, request counts, lengths, concurrency, and result path, remain top-level config fields and cannot be overridden through `args`.
+- **`aiperf` is a client-side load generator** run against the live server (`http://127.0.0.1:<port>`). The wrapper owns `--model`, `--tokenizer` (defaults to the served model), `--url`, `--api-key EMPTY`, and `--output-artifact-dir`; every other flag goes under `args` and follows the same normalization as `vllm_bench.configs[].args` (underscores/hyphens/`--` prefix accepted, `true` emits a bare flag, lists repeat the flag, comma-separated sweep values like `concurrency: "16,24"` should stay quoted strings). Because the vLLM images don't ship aiperf, it is `pip install`ed on first use (into the container for Docker runtime, into the job Python for native runtime).
 - **`bfcl` may need tool-call serve args.** Some models require `--enable-auto-tool-choice` and `--tool-call-parser` for function-calling; the parser warns if `--tool-call-parser` is absent. Each category runs as a separate generate + evaluate pass; scores appear on the eval dashboard as `bfcl_<category>` tasks.
 - **`bfcl.maximum_step_limit`** caps how many inference steps BFCL allows per multi-turn turn (default 10 in perf-eval; BFCL upstream defaults to 20). Set it in the workload YAML, or override per-run with the `BFCL_MAXIMUM_STEP_LIMIT` env var (env wins over YAML). Useful for agentic / long multi-turn categories.
 - **`bfcl.max_test_cases`** subsamples a category instead of running the full set — e.g. `multi_turn` (~800 cases) down to 300. For aggregate groups with multiple subcategories, the cap is split evenly across subcategories (by BFCL id order within each). Set a single integer to cap every category, or a map per category (`multi_turn: 240`). Override per-run with `BFCL_MAX_TEST_CASES`. Scores are partial-eval only and are not comparable to full BFCL leaderboard numbers.

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -36,6 +36,11 @@ BENCH_RESERVED_ARGS = {
     "speed-bench-category", "skip-tokenizer-init", "save-result",
     "result-filename",
 }
+AIPERF_FIELDS = {"name", "args"}
+AIPERF_REQUIRED = ("name",)
+AIPERF_RESERVED_ARGS = {
+    "model", "tokenizer", "url", "api-key", "output-artifact-dir",
+}
 BFCL_FIELDS = {
     "test_categories", "num_threads", "temperature",
     "maximum_step_limit", "max_test_cases",
@@ -188,31 +193,42 @@ def normalize_bench_arg_name(name: str) -> str:
     return name.lstrip("-").replace("_", "-")
 
 
-def encode_bench_args(args: object, config_name: str, path: str) -> str:
+def encode_arg_map(
+    args: object, config_name: str, path: str, reserved: set, kind: str
+) -> str:
+    """Normalize a config `args` map to `--kebab-case` keys and base64-encode it.
+
+    Shared by vllm_bench and aiperf; each passes its own set of wrapper-owned
+    reserved options that a workload must not override.
+    """
     if args is None:
         args = {}
     if not isinstance(args, dict):
-        sys.exit(f"{path}: vllm_bench config {config_name!r} args must be a map")
+        sys.exit(f"{path}: {kind} config {config_name!r} args must be a map")
     normalized = {}
     for name, value in args.items():
         if not isinstance(name, str) or not normalize_bench_arg_name(name):
             sys.exit(
-                f"{path}: vllm_bench config {config_name!r} args keys must be non-empty strings"
+                f"{path}: {kind} config {config_name!r} args keys must be non-empty strings"
             )
         normalized_name = normalize_bench_arg_name(name)
-        if normalized_name in BENCH_RESERVED_ARGS:
+        if normalized_name in reserved:
             sys.exit(
-                f"{path}: vllm_bench config {config_name!r} args cannot override "
+                f"{path}: {kind} config {config_name!r} args cannot override "
                 f"wrapper-owned option --{normalized_name}"
             )
         if normalized_name in normalized:
             sys.exit(
-                f"{path}: vllm_bench config {config_name!r} args contains duplicate "
+                f"{path}: {kind} config {config_name!r} args contains duplicate "
                 f"option --{normalized_name} after normalization"
             )
         normalized[normalized_name] = value
     payload = json.dumps(normalized, separators=(",", ":")).encode()
     return base64.b64encode(payload).decode()
+
+
+def encode_bench_args(args: object, config_name: str, path: str) -> str:
+    return encode_arg_map(args, config_name, path, BENCH_RESERVED_ARGS, "vllm_bench")
 
 
 def bench_tsv(configs: list, path: str) -> str:
@@ -249,6 +265,40 @@ def bench_tsv(configs: list, path: str) -> str:
                     opt("speed_bench_dataset_subset"),
                     opt("speed_bench_category"),
                     encode_bench_args(c.get("args"), c["name"], path),
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def aiperf_tsv(configs: list, path: str) -> str:
+    """Emit one row per aiperf config: name plus base64-encoded arg map.
+
+    The wrapper owns --model, --tokenizer, --url, --api-key, and
+    --output-artifact-dir; everything else the profile needs goes under `args`.
+    """
+    seen = set()
+    lines = []
+    for c in configs:
+        extra = set(c) - AIPERF_FIELDS
+        if extra:
+            sys.exit(
+                f"{path}: aiperf config {c.get('name')!r} has unsupported "
+                f"fields {sorted(extra)}; allowed: {sorted(AIPERF_FIELDS)}"
+            )
+        for k in AIPERF_REQUIRED:
+            if c.get(k) is None:
+                sys.exit(f"{path}: aiperf config {c.get('name')!r} missing required field {k!r}")
+        if c["name"] in seen:
+            sys.exit(f"{path}: duplicate aiperf config name {c['name']!r}")
+        seen.add(c["name"])
+        lines.append(
+            "\t".join(
+                [
+                    c["name"],
+                    encode_arg_map(
+                        c.get("args"), c["name"], path, AIPERF_RESERVED_ARGS, "aiperf"
+                    ),
                 ]
             )
         )
@@ -342,13 +392,17 @@ def main(path: str) -> None:
     lm_eval = data.get("lm_eval") or {}
     bench = data.get("vllm_bench") or {}
 
+    aiperf = data.get("aiperf") or {}
+
     tasks = lm_eval.get("tasks") or []
     bfcl = data.get("bfcl") or {}
     bench_configs = bench.get("configs") or []
+    aiperf_configs = aiperf.get("configs") or []
 
-    if not tasks and not bench_configs and not bfcl:
+    if not tasks and not bench_configs and not bfcl and not aiperf_configs:
         sys.exit(
-            f"{path}: workload must define at least one of lm_eval, vllm_bench, or bfcl"
+            f"{path}: workload must define at least one of lm_eval, vllm_bench, "
+            f"aiperf, or bfcl"
         )
 
     if tasks:
@@ -377,6 +431,7 @@ def main(path: str) -> None:
     emit("ENV", "\n".join(f"{k}={fmt(v)}" for k, v in env.items()))
     emit("LM_EVAL_TASKS_TSV", task_tsv(tasks, lm_eval.get("model_args") or {}))
     emit("VLLM_BENCH_TSV", bench_tsv(bench_configs, path))
+    emit("AIPERF_TSV", aiperf_tsv(aiperf_configs, path))
     emit("BFCL_TSV", bfcl_tsv(bfcl) if bfcl else "")
     emit("BENCH_DEVICE", metadata.get("device") or gpu.lower())
     emit("BENCH_TP", tp)

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -15,6 +15,8 @@ source "$DIR/server.sh"
 source "$DIR/run_lm_eval.sh"
 # shellcheck disable=SC1091
 source "$DIR/run_vllm_bench.sh"
+# shellcheck disable=SC1091
+source "$DIR/run_aiperf.sh"
 WORKLOAD_EXPORTS="$(python3 "$DIR/parse_workload.py" "$WORKLOAD")"
 eval "$WORKLOAD_EXPORTS"
 export WORKLOAD_IMAGE WORKLOAD_VLLM_COMMIT WORKLOAD_SERVER_RUNTIME
@@ -56,6 +58,14 @@ while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc speed_subset
     --image "$WORKLOAD_IMAGE" \
     --isl "$isl" --osl "$osl" --conc "$conc" || true
 done <<< "$WORKLOAD_VLLM_BENCH_TSV"
+
+# aiperf profile runs (perf, like vllm_bench). Artifacts are uploaded via the
+# Buildkite artifact_paths glob; there is no dashboard ingest for aiperf yet.
+while IFS=$'\t' read -r aname aargs; do
+  [[ -z "$aname" ]] && continue
+  run_aiperf "$CONTAINER" "$PORT" "$WORKLOAD_MODEL" \
+             "$aname" "$aargs" "$RESULTS_DIR"
+done <<< "$WORKLOAD_AIPERF_TSV"
 
 if [[ "${BENCH_ONLY:-}" =~ ^([Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss])$ ]]; then
   echo "--- :stopwatch: BENCH_ONLY set; skipping lm_eval and bfcl tasks"

--- a/lib/run_aiperf.sh
+++ b/lib/run_aiperf.sh
@@ -1,0 +1,61 @@
+# Run a single `aiperf profile` config against the running vLLM container.
+# Source this from run.sh *after* run_vllm_bench.sh, which provides the
+# pip_install_quiet and append_bench_args helpers this file reuses.
+#
+# Usage:
+#   run_aiperf <container> <port> <model> <name> <args_base64> <output_dir>
+#
+# aiperf is a client-side load generator that is not shipped in the
+# vllm/vllm-openai images, so it is pip-installed on first use. Native runtime
+# installs it into the job's Python; Docker runtime installs and runs it inside
+# the vLLM container. Artifacts land in "<output_dir>/aiperf-<name>/" and are
+# picked up by the Buildkite artifact upload.
+
+ensure_aiperf() {
+  local runtime=$1 container=$2
+  if [[ "$runtime" == "native" ]]; then
+    command -v aiperf >/dev/null 2>&1 && return 0
+    echo "--- :package: installing aiperf"
+    pip_install_quiet aiperf
+  else
+    docker exec "$container" bash -lc 'command -v aiperf >/dev/null 2>&1' && return 0
+    echo "--- :package: installing aiperf in vLLM container"
+    docker exec "$container" bash -lc \
+      'PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --quiet aiperf \
+        || PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user --quiet aiperf'
+  fi
+}
+
+run_aiperf() {
+  local container=$1 port=$2 model=$3 name=$4 args_base64=$5 outdir=$6
+  local runtime="${WORKLOAD_SERVER_RUNTIME:-docker}"
+  local url="http://127.0.0.1:${port}"
+  local host_dir="${outdir}/aiperf-${name}"
+  local in_container_dir="/tmp/aiperf-${name}"
+
+  echo "--- :chart_with_upwards_trend: aiperf profile ${name}"
+  mkdir -p "$host_dir"
+  ensure_aiperf "$runtime" "$container"
+
+  local artifact_dir="$host_dir"
+  [[ "$runtime" != "native" ]] && artifact_dir="$in_container_dir"
+
+  local cmd=(
+    aiperf profile
+    --model "$model"
+    --tokenizer "$model"
+    --url "$url"
+    --api-key EMPTY
+    --output-artifact-dir "$artifact_dir"
+  )
+  [[ "$runtime" != "native" ]] && cmd=(docker exec "$container" "${cmd[@]}")
+
+  append_bench_args "$args_base64" cmd
+
+  "${cmd[@]}"
+
+  if [[ "$runtime" != "native" ]]; then
+    docker cp "${container}:${in_container_dir}/." "$host_dir/"
+  fi
+  echo "  saved aiperf artifacts to $host_dir"
+}

--- a/workloads/kimi_k2_5_mi355x.yaml
+++ b/workloads/kimi_k2_5_mi355x.yaml
@@ -8,6 +8,7 @@ vllm:
   model: moonshotai/Kimi-K2.5
   env:
     VLLM_ROCM_USE_AITER: 1
+    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code

--- a/workloads/kimi_k3_mi355x.yaml
+++ b/workloads/kimi_k3_mi355x.yaml
@@ -11,6 +11,7 @@ vllm:
     AITER_SITUV2_A8W4: 1
     AITER_BF16_FP8_MOE_BOUND: 0
     VLLM_USE_BREAKABLE_CUDAGRAPH: 0
+    OMP_NUM_THREADS: 1
   serve_args: >-
     --trust-remote-code
     --tensor-parallel-size 8

--- a/workloads/kimi_k3_mi355x.yaml
+++ b/workloads/kimi_k3_mi355x.yaml
@@ -1,0 +1,49 @@
+# Kimi-K3 on AMD MI355X (aiperf perf run)
+name: kimi_k3-mi355x
+gpu: MI355X
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: moonshotai/Kimi-K3
+  env:
+    VLLM_ROCM_USE_AITER: 1
+    AITER_SITUV2_A8W4: 1
+    AITER_BF16_FP8_MOE_BOUND: 0
+    VLLM_USE_BREAKABLE_CUDAGRAPH: 0
+  serve_args: >-
+    --trust-remote-code
+    --tensor-parallel-size 8
+    --gpu-memory-utilization 0.95
+    --mm-encoder-tp-mode data
+    --max-num-batched-tokens 4096
+    --enable-auto-tool-choice
+    --tool-call-parser kimi_k3
+    --reasoning-parser kimi_k3
+    --max-num-seqs 128
+    --enable-prefix-caching
+
+aiperf:
+  configs:
+    - name: prefix63k-in4760-out350-conc16-24
+      args:
+        endpoint-type: chat
+        streaming: true
+        use-server-token-count: true
+        tokenizer-trust-remote-code: true
+        num-prefix-prompts: 8
+        prompt-prefix-length: 63240
+        synthetic-input-tokens-mean: 4760
+        synthetic-input-tokens-stddev: 0
+        output-tokens-mean: 350
+        output-tokens-stddev: 0
+        extra-inputs:
+          - "ignore_eos:true"
+          - "min_tokens:350"
+          - "max_tokens:350"
+        warmup-request-count: 3
+        sweep-type: zip
+        concurrency: "16,24"
+        request-count: "80,120"
+        random-seed: 42
+        ui: simple


### PR DESCRIPTION
Add the ability to run `aiperf` (https://github.com/ai-dynamo/aiperf) in `perf-eval`. This PR does not implement a POST for the results of `aiperf` as they aren't yet shown on the dashboard. That can come in a future PR. 

I have also added a Kimi-K3 workload to test `aiperf` on MI355X. Green BK Checkout here: https://buildkite.com/vllm/perf-eval/builds/447

This was implemented with assistance from Claude.