### PR TITLE
feat: Support a list of concurrencies for bench configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ bfcl:                    # function-calling eval (optional)
 
 vllm_bench:              # perf runs (optional) — fed to the perf dashboard
   configs:
-    - name: 1k-in-1k-out-conc-256
+    - name: 1k-in-1k-out
       backend: openai                 # /v1/completions — exact ISL/OSL, no chat template
       dataset: random                 # synthetic fixed-length throughput dataset
       input_len: 1024
       output_len: 1024
       num_prompts: 500
-      max_concurrency: 256
+      max_concurrency: [1, 64, 256]     # single value, or a list to sweep concurrency
       args:                             # optional vllm bench serve arguments
         num_warmups: 16                 # becomes --num-warmups 16
         disable_tqdm: true              # becomes --disable-tqdm
@@ -96,6 +96,7 @@ A few things worth knowing:
 - **`lm_eval.tasks` is a list** because each entry runs as a separate `lm_eval` invocation — `--num_fewshot` is a single global flag, so different shot counts need separate runs. Each task's results land in `results/<name>/<task-name>/`.
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
 - **`vllm_bench` uses the `random` dataset with `--ignore-eos`** so every request prefills exactly `input_len` and decodes exactly `output_len` tokens — that's what makes the per-GPU decode throughput meaningful. Pair it with `backend: openai` (the `/v1/completions` endpoint) for exact token control. Avoid `dataset: speed_bench` for throughput numbers: it requires `--skip-tokenizer-init`, which makes `vllm bench serve` cap every request at a single output token, so output throughput reads as ~0.
+- **`vllm_bench.configs[].max_concurrency` may be a single value or a list.** Each run's name is always `<name>-conc-<value>`, so the config `name` is the shape description *without* the concurrency (e.g. `name: 8k-in-1k-out`). A scalar (`max_concurrency: 128`) produces one run (`8k-in-1k-out-conc-128`); a list (`max_concurrency: [1, 64, 128]`) sweeps concurrency and fans out into one run per value, so you don't have to copy a config per concurrency. `num_prompts` can stay a single value (applied to every run) or, when `max_concurrency` is a list, be a list of the same length to set a per-concurrency request count (e.g. to keep `num_prompts` proportional to concurrency).
 - **`vllm_bench.configs[].args` forwards additional options to `vllm bench serve`.** Keys may use underscores, hyphens, or a leading `--`; they are normalized to `--kebab-case`. A `true` value emits a standalone flag, `false` and `null` omit it, scalar values emit a flag/value pair, and lists repeat the flag. Options managed by perf-eval itself, including the model, endpoint, dataset, request counts, lengths, concurrency, and result path, remain top-level config fields and cannot be overridden through `args`.
 - **`bfcl` may need tool-call serve args.** Some models require `--enable-auto-tool-choice` and `--tool-call-parser` for function-calling; the parser warns if `--tool-call-parser` is absent. Each category runs as a separate generate + evaluate pass; scores appear on the eval dashboard as `bfcl_<category>` tasks.
 - **`bfcl.maximum_step_limit`** caps how many inference steps BFCL allows per multi-turn turn (default 10 in perf-eval; BFCL upstream defaults to 20). Set it in the workload YAML, or override per-run with the `BFCL_MAXIMUM_STEP_LIMIT` env var (env wins over YAML). Useful for agentic / long multi-turn categories.

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -12,6 +12,8 @@ Image precedence: VLLM_IMAGE > VLLM_COMMIT > workload `vllm.image` >
 are not validated against the registry (because they will not run).
 """
 
+from __future__ import annotations
+
 import base64
 import json
 import os

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -216,7 +216,7 @@ def encode_bench_args(args: object, config_name: str, path: str) -> str:
 
 
 def _positive_int(value: object) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+    return isinstance(value, int) and value > 0
 
 
 def expand_bench_config(c: dict, path: str) -> list:

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -215,10 +215,6 @@ def encode_bench_args(args: object, config_name: str, path: str) -> str:
     return base64.b64encode(payload).decode()
 
 
-def _positive_int(value: object) -> bool:
-    return isinstance(value, int) and value > 0
-
-
 def expand_bench_config(c: dict, path: str) -> list:
     """Expand a bench config's concurrency sweep into concrete runs.
 
@@ -238,12 +234,6 @@ def expand_bench_config(c: dict, path: str) -> list:
     concs = mc if is_sweep else [mc]
     if is_sweep and not concs:
         sys.exit(f"{path}: vllm_bench config {name!r} has an empty max_concurrency list")
-    for v in concs:
-        if not _positive_int(v):
-            sys.exit(
-                f"{path}: vllm_bench config {name!r} max_concurrency must be a positive "
-                f"integer or a list of positive integers"
-            )
 
     if isinstance(npr, list):
         if not is_sweep:
@@ -260,7 +250,7 @@ def expand_bench_config(c: dict, path: str) -> list:
     else:
         nprompts = [npr] * len(concs)
     for v in nprompts:
-        if not _positive_int(v):
+        if not (isinstance(v, int) and v > 0):
             sys.exit(
                 f"{path}: vllm_bench config {name!r} num_prompts must be a positive integer "
                 f"(or a list of them matching max_concurrency)"

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -215,6 +215,63 @@ def encode_bench_args(args: object, config_name: str, path: str) -> str:
     return base64.b64encode(payload).decode()
 
 
+def _positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def expand_bench_config(c: dict, path: str) -> list:
+    """Expand a bench config's concurrency sweep into concrete runs.
+
+    max_concurrency may be a single int or a list of
+    them (one run per value). Either way each run's name is suffixed with
+    `-conc-<value>`, so the config name is the shape description without the
+    concurrency. `num_prompts` is either a single value applied to every run,
+    or — only when `max_concurrency` is a list — a list of the same length
+    giving a per-concurrency request count. Returns a list of
+    (name, num_prompts, max_concurrency) tuples.
+    """
+    name = c["name"]
+    mc = c["max_concurrency"]
+    npr = c["num_prompts"]
+    is_sweep = isinstance(mc, list)
+
+    concs = mc if is_sweep else [mc]
+    if is_sweep and not concs:
+        sys.exit(f"{path}: vllm_bench config {name!r} has an empty max_concurrency list")
+    for v in concs:
+        if not _positive_int(v):
+            sys.exit(
+                f"{path}: vllm_bench config {name!r} max_concurrency must be a positive "
+                f"integer or a list of positive integers"
+            )
+
+    if isinstance(npr, list):
+        if not is_sweep:
+            sys.exit(
+                f"{path}: vllm_bench config {name!r} num_prompts may only be a list when "
+                f"max_concurrency is a list"
+            )
+        if len(npr) != len(concs):
+            sys.exit(
+                f"{path}: vllm_bench config {name!r} num_prompts list has {len(npr)} entries "
+                f"but max_concurrency has {len(concs)}"
+            )
+        nprompts = npr
+    else:
+        nprompts = [npr] * len(concs)
+    for v in nprompts:
+        if not _positive_int(v):
+            sys.exit(
+                f"{path}: vllm_bench config {name!r} num_prompts must be a positive integer "
+                f"(or a list of them matching max_concurrency)"
+            )
+
+    return [
+        (f"{name}-conc-{conc}", n, conc)
+        for conc, n in zip(concs, nprompts)
+    ]
+
+
 def bench_tsv(configs: list, path: str) -> str:
     seen = set()
     lines = []
@@ -228,30 +285,32 @@ def bench_tsv(configs: list, path: str) -> str:
         for k in BENCH_REQUIRED:
             if c.get(k) is None:
                 sys.exit(f"{path}: vllm_bench config {c.get('name')!r} missing required field {k!r}")
-        if c["name"] in seen:
-            sys.exit(f"{path}: duplicate vllm_bench config name {c['name']!r}")
-        seen.add(c["name"])
 
         def opt(key):
-            v = c.get(key)
+            v = c.get(key)  # noqa: B023
             return str(v) if v not in (None, "") else "-"
 
-        lines.append(
-            "\t".join(
-                [
-                    c["name"],
-                    opt("backend"),
-                    str(c.get("dataset", "random")),
-                    str(c["input_len"]),
-                    str(c["output_len"]),
-                    str(c["num_prompts"]),
-                    str(c["max_concurrency"]),
-                    opt("speed_bench_dataset_subset"),
-                    opt("speed_bench_category"),
-                    encode_bench_args(c.get("args"), c["name"], path),
-                ]
+        encoded_args = encode_bench_args(c.get("args"), c["name"], path)
+        for run_name, nprompts, conc in expand_bench_config(c, path):
+            if run_name in seen:
+                sys.exit(f"{path}: duplicate vllm_bench config name {run_name!r}")
+            seen.add(run_name)
+            lines.append(
+                "\t".join(
+                    [
+                        run_name,
+                        opt("backend"),
+                        str(c.get("dataset", "random")),
+                        str(c["input_len"]),
+                        str(c["output_len"]),
+                        str(nprompts),
+                        str(conc),
+                        opt("speed_bench_dataset_subset"),
+                        opt("speed_bench_category"),
+                        encoded_args,
+                    ]
+                )
             )
-        )
     return "\n".join(lines)
 
 

--- a/workloads/deepseek_v4_pro_5_h200.yaml
+++ b/workloads/deepseek_v4_pro_5_h200.yaml
@@ -52,7 +52,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/deepseek_v4_pro_mi355x.yaml
+++ b/workloads/deepseek_v4_pro_mi355x.yaml
@@ -30,7 +30,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/gemma_4_31b_it_h200.yaml
+++ b/workloads/gemma_4_31b_it_h200.yaml
@@ -37,7 +37,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/glm_5_1_h200.yaml
+++ b/workloads/glm_5_1_h200.yaml
@@ -41,7 +41,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/gpt_oss_120b_b200.yaml
+++ b/workloads/gpt_oss_120b_b200.yaml
@@ -43,7 +43,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -36,7 +36,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/gpt_oss_120b_mi355x.yaml
+++ b/workloads/gpt_oss_120b_mi355x.yaml
@@ -28,7 +28,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/kimi_k2_5_h200.yaml
+++ b/workloads/kimi_k2_5_h200.yaml
@@ -40,7 +40,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/kimi_k2_5_mi300x.yaml
+++ b/workloads/kimi_k2_5_mi300x.yaml
@@ -27,7 +27,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/kimi_k2_5_mi355x.yaml
+++ b/workloads/kimi_k2_5_mi355x.yaml
@@ -27,7 +27,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/minimax_m2_5_h200.yaml
+++ b/workloads/minimax_m2_5_h200.yaml
@@ -43,7 +43,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/minimax_m2_5_mi300x.yaml
+++ b/workloads/minimax_m2_5_mi300x.yaml
@@ -28,7 +28,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/minimax_m2_5_mi355x.yaml
+++ b/workloads/minimax_m2_5_mi355x.yaml
@@ -28,7 +28,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/minimax_m3_b200.yaml
+++ b/workloads/minimax_m3_b200.yaml
@@ -46,7 +46,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-16
+    - name: 8k-in-1k-out
       backend: openai-chat
       dataset: random
       input_len: 8192

--- a/workloads/minimax_m3_mi355x.yaml
+++ b/workloads/minimax_m3_mi355x.yaml
@@ -38,7 +38,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-16
+    - name: 8k-in-1k-out
       backend: openai-chat
       dataset: random
       input_len: 8192

--- a/workloads/nemotron_3_super_5_h200.yaml
+++ b/workloads/nemotron_3_super_5_h200.yaml
@@ -45,7 +45,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/qwen3_5_b200.yaml
+++ b/workloads/qwen3_5_b200.yaml
@@ -37,7 +37,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/qwen3_5_h200.yaml
+++ b/workloads/qwen3_5_h200.yaml
@@ -29,7 +29,7 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/qwen3_5_mi355x.yaml
+++ b/workloads/qwen3_5_mi355x.yaml
@@ -28,10 +28,10 @@ lm_eval:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192
       output_len: 1024
-      num_prompts: 512
-      max_concurrency: 128
+      num_prompts: [10, 512]
+      max_concurrency: [1, 128]


### PR DESCRIPTION
This PR allows us to specify a list of concurrencies for bench configs in workloads. For example:
```
vllm_bench:
  configs:
    - name: 8k-in-1k-out
      backend: openai
      dataset: random
      input_len: 8192
      output_len: 1024
      num_prompts: 512
      max_concurrency: [1, 64, 128]
```

The above would run a an 8k/1k benchmark for each concurrency listed (1, 64, 128). You can also optionally change `num_prompts` to a list to correspond to each max_concurrency, e.g.:

```
vllm_bench:
  configs:
    - name: 8k-in-1k-out
      backend: openai
      dataset: random
      input_len: 8192
      output_len: 1024
      num_prompts: [10, 64, 1280]
      max_concurrency: [1, 64, 128]
```

In `expand_bench_config`, `-conc-<value>` is appended to each config's `name` for each conc, so in the above example the final names for the config would be `8k-in-1k-out-conc-1`, `8k-in-1k-out-conc-64`, `8k-in-1k-out-conc-128`. 

I've updated `workloads/qwen3_5_mi355x.yaml` as an initial example. 