### PR TITLE
Stabilize H200 serving benchmarks

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,4 +5,6 @@ steps:
     commands:
       - python3 -m ensurepip --upgrade --default-pip 2>/dev/null || true
       - python3 -m pip install --user pyyaml
+      - python3 .buildkite/test_generate_pipeline.py
+      - python3 .buildkite/test_benchmark_repetitions.py
       - export PATH="$HOME/.local/bin:$PATH" && python3 .buildkite/generate_pipeline.py | buildkite-agent pipeline upload

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Stdlib + PyYAML regression tests for repeated serving benchmarks."""
+
+import base64
+import copy
+import importlib.util
+import json
+import os
+import sys
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(ROOT, relative_path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+aggregate_perf = load_module("aggregate_perf", "lib/aggregate_perf.py")
+parse_workload = load_module("parse_workload", "lib/parse_workload.py")
+
+
+def benchmark_config(**overrides):
+    config = {
+        "name": "test",
+        "backend": "openai",
+        "dataset": "random",
+        "input_len": 8192,
+        "output_len": 1024,
+        "num_prompts": 512,
+        "max_concurrency": 128,
+    }
+    config.update(overrides)
+    return config
+
+
+def raw_result(**overrides):
+    result = {
+        "backend": "openai",
+        "model_id": "model",
+        "tokenizer_id": "tokenizer",
+        "num_prompts": 512,
+        "max_concurrency": 128,
+        "completed": 512,
+        "failed": 0,
+        "mean_ttft_ms": 100.0,
+        "p99_ttft_ms": 150.0,
+        "request_rate": "inf",
+    }
+    result.update(overrides)
+    return result
+
+
+def test_parser_defaults_to_one_repetition():
+    fields = parse_workload.bench_tsv(
+        [benchmark_config()], "workload.yaml"
+    ).split("\t")
+    assert fields[7] == "1", fields
+
+
+def test_parser_emits_repetitions_and_warmups():
+    fields = parse_workload.bench_tsv(
+        [
+            benchmark_config(
+                repetitions=3,
+                args={"num_warmups": 128},
+            )
+        ],
+        "workload.yaml",
+    ).split("\t")
+    assert fields[7] == "3", fields
+    args = json.loads(base64.b64decode(fields[10]))
+    assert args == {"num-warmups": 128}, args
+
+
+def test_parser_rejects_non_positive_or_even_repetitions():
+    for repetitions in (0, 2, -1, True):
+        try:
+            parse_workload.bench_tsv(
+                [benchmark_config(repetitions=repetitions)], "workload.yaml"
+            )
+        except SystemExit as exc:
+            assert "positive odd integer" in str(exc), exc
+        else:
+            raise AssertionError(f"accepted repetitions={repetitions!r}")
+
+
+def test_aggregate_uses_run_level_median_and_retains_metadata():
+    aggregate = aggregate_perf.aggregate_results(
+        [
+            raw_result(mean_ttft_ms=130.0, p99_ttft_ms=210.0),
+            raw_result(mean_ttft_ms=100.0, p99_ttft_ms=150.0),
+            raw_result(mean_ttft_ms=110.0, p99_ttft_ms=180.0),
+        ],
+        ["run-1.json", "run-2.json", "run-3.json"],
+    )
+    assert aggregate["mean_ttft_ms"] == 110.0, aggregate
+    assert aggregate["p99_ttft_ms"] == 180.0, aggregate
+    assert aggregate["request_rate"] == "inf", aggregate
+    assert aggregate["aggregation_method"] == "median", aggregate
+    assert aggregate["aggregated_repetitions"] == 3, aggregate
+    assert aggregate["individual_result_files"] == [
+        "run-1.json",
+        "run-2.json",
+        "run-3.json",
+    ], aggregate
+
+
+def test_aggregate_rejects_mismatched_identity():
+    mismatched = copy.deepcopy(raw_result())
+    mismatched["model_id"] = "different-model"
+    try:
+        aggregate_perf.aggregate_results(
+            [raw_result(), mismatched, raw_result()],
+            ["run-1.json", "run-2.json", "run-3.json"],
+        )
+    except ValueError as exc:
+        assert "model_id" in str(exc), exc
+    else:
+        raise AssertionError("accepted mismatched model identities")
+
+
+def test_all_h200_benchmarks_use_saturated_warmups_and_three_runs():
+    import yaml
+
+    workload_dir = os.path.join(ROOT, "workloads")
+    paths = sorted(
+        os.path.join(workload_dir, name)
+        for name in os.listdir(workload_dir)
+        if name.endswith("_h200.yaml")
+    )
+    assert paths, "no H200 workloads found"
+    for path in paths:
+        with open(path) as f:
+            workload = yaml.safe_load(f)
+        for config in (workload.get("vllm_bench") or {}).get("configs") or []:
+            assert config.get("repetitions") == 3, path
+            assert (config.get("args") or {}).get("num_warmups") == config.get(
+                "max_concurrency"
+            ), path
+
+
+def main():
+    tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"ok   {test.__name__}")
+        except (AssertionError, ValueError) as exc:
+            failed += 1
+            print(f"FAIL {test.__name__}: {exc}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ vllm_bench:              # perf runs (optional) — fed to the perf dashboard
       output_len: 1024
       num_prompts: 500
       max_concurrency: 256
+      repetitions: 3                   # median-aggregate three complete runs
       args:                             # optional vllm bench serve arguments
-        num_warmups: 16                 # becomes --num-warmups 16
+        num_warmups: 256                # one full-concurrency warmup per run
         disable_tqdm: true              # becomes --disable-tqdm
 ```
 
@@ -97,6 +98,7 @@ A few things worth knowing:
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
 - **`vllm_bench` uses the `random` dataset with `--ignore-eos`** so every request prefills exactly `input_len` and decodes exactly `output_len` tokens — that's what makes the per-GPU decode throughput meaningful. Pair it with `backend: openai` (the `/v1/completions` endpoint) for exact token control. Avoid `dataset: speed_bench` for throughput numbers: it requires `--skip-tokenizer-init`, which makes `vllm bench serve` cap every request at a single output token, so output throughput reads as ~0.
 - **`vllm_bench.configs[].args` forwards additional options to `vllm bench serve`.** Keys may use underscores, hyphens, or a leading `--`; they are normalized to `--kebab-case`. A `true` value emits a standalone flag, `false` and `null` omit it, scalar values emit a flag/value pair, and lists repeat the flag. Options managed by perf-eval itself, including the model, endpoint, dataset, request counts, lengths, concurrency, and result path, remain top-level config fields and cannot be overridden through `args`.
+- **`vllm_bench.configs[].repetitions` repeats the complete benchmark on the same server and median-aggregates every numeric scalar before ingestion.** It defaults to `1` and must be a positive odd integer. For repeated configs, every raw run is retained as `bench-<name>-run-<n>.json`; the median aggregate remains `bench-<name>.json`. `args.num_warmups` applies independently to every repetition, so set it to the configured concurrency for one saturated warmup wave per measured run.
 - **`bfcl` may need tool-call serve args.** Some models require `--enable-auto-tool-choice` and `--tool-call-parser` for function-calling; the parser warns if `--tool-call-parser` is absent. Each category runs as a separate generate + evaluate pass; scores appear on the eval dashboard as `bfcl_<category>` tasks.
 - **`bfcl.maximum_step_limit`** caps how many inference steps BFCL allows per multi-turn turn (default 10 in perf-eval; BFCL upstream defaults to 20). Set it in the workload YAML, or override per-run with the `BFCL_MAXIMUM_STEP_LIMIT` env var (env wins over YAML). Useful for agentic / long multi-turn categories.
 - **`bfcl.max_test_cases`** subsamples a category instead of running the full set — e.g. `multi_turn` (~800 cases) down to 300. For aggregate groups with multiple subcategories, the cap is split evenly across subcategories (by BFCL id order within each). Set a single integer to cap every category, or a map per category (`multi_turn: 240`). Override per-run with `BFCL_MAX_TEST_CASES`. Scores are partial-eval only and are not comparable to full BFCL leaderboard numbers.
@@ -119,7 +121,14 @@ A cluster with fast shared storage can keep a warm, cross-run cache by overridin
 
 Do **not** set an `hf_home` under a node path like `/mnt/shared` unless that path is a real mount on every node in the queue — with the default `emptyDir` that only changes the in-pod path, but if you also point the volume at a `hostPath`, an unmounted path lands the cache on the node root disk with no reclamation.
 
-Run the generator's tests with `python3 .buildkite/test_generate_pipeline.py` (stdlib + pyyaml only; no GPU needed).
+Run the CPU-only regression tests with:
+
+```bash
+python3 .buildkite/test_generate_pipeline.py
+python3 .buildkite/test_benchmark_repetitions.py
+```
+
+They require only the standard library and PyYAML; the Buildkite bootstrap runs both before uploading GPU steps.
 
 ### Trigger a Buildkite build
 

--- a/lib/aggregate_perf.py
+++ b/lib/aggregate_perf.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Median-aggregate repeated ``vllm bench serve`` result files."""
+
+import argparse
+import json
+import numbers
+import os
+import statistics
+
+
+IDENTITY_KEYS = (
+    "backend",
+    "model_id",
+    "tokenizer_id",
+    "num_prompts",
+    "max_concurrency",
+)
+
+
+def aggregate_results(results: list[dict], source_paths: list[str]) -> dict:
+    if not results:
+        raise ValueError("at least one benchmark result is required")
+
+    first = results[0]
+    if not isinstance(first, dict):
+        raise ValueError("benchmark results must be JSON objects")
+
+    first_keys = set(first)
+    for index, result in enumerate(results[1:], start=2):
+        if not isinstance(result, dict):
+            raise ValueError(f"benchmark result {index} is not a JSON object")
+        if set(result) != first_keys:
+            raise ValueError(f"benchmark result {index} has a different schema")
+
+    for key in IDENTITY_KEYS:
+        values = [result.get(key) for result in results]
+        if any(value != values[0] for value in values[1:]):
+            raise ValueError(f"benchmark results disagree on {key}: {values}")
+
+    aggregate = dict(first)
+    for key in first:
+        values = [result[key] for result in results]
+        if all(
+            isinstance(value, numbers.Real) and not isinstance(value, bool)
+            for value in values
+        ):
+            aggregate[key] = statistics.median(values)
+
+    aggregate["aggregation_method"] = "median"
+    aggregate["aggregated_repetitions"] = len(results)
+    aggregate["individual_result_files"] = [
+        os.path.basename(path) for path in source_paths
+    ]
+    return aggregate
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("results", nargs="+")
+    args = parser.parse_args()
+
+    loaded = []
+    for path in args.results:
+        with open(path) as f:
+            loaded.append(json.load(f))
+
+    aggregate = aggregate_results(loaded, args.results)
+    with open(args.output, "w") as f:
+        json.dump(aggregate, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(
+        f"  median aggregate: {len(loaded)} repetitions -> {args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -24,7 +24,7 @@ import yaml
 TASK_FIELDS = {"name", "num_fewshot", "model_args"}
 BENCH_FIELDS = {
     "name", "backend", "dataset", "input_len", "output_len",
-    "num_prompts", "max_concurrency", "args",
+    "num_prompts", "max_concurrency", "repetitions", "args",
     "speed_bench_dataset_subset", "speed_bench_category",
 }
 BENCH_REQUIRED = ("name", "input_len", "output_len", "num_prompts", "max_concurrency")
@@ -232,6 +232,18 @@ def bench_tsv(configs: list, path: str) -> str:
             sys.exit(f"{path}: duplicate vllm_bench config name {c['name']!r}")
         seen.add(c["name"])
 
+        repetitions = c.get("repetitions", 1)
+        if (
+            isinstance(repetitions, bool)
+            or not isinstance(repetitions, int)
+            or repetitions < 1
+            or repetitions % 2 == 0
+        ):
+            sys.exit(
+                f"{path}: vllm_bench config {c['name']!r} repetitions must be "
+                "a positive odd integer"
+            )
+
         def opt(key):
             v = c.get(key)
             return str(v) if v not in (None, "") else "-"
@@ -246,6 +258,7 @@ def bench_tsv(configs: list, path: str) -> str:
                     str(c["output_len"]),
                     str(c["num_prompts"]),
                     str(c["max_concurrency"]),
+                    str(repetitions),
                     opt("speed_bench_dataset_subset"),
                     opt("speed_bench_category"),
                     encode_bench_args(c.get("args"), c["name"], path),

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -40,11 +40,12 @@ wait_healthy "$PORT"
 # on a full lm_eval pass. Each config's raw json lands in
 # $RESULTS_DIR/bench-<name>.json and is then transformed and POSTed to the
 # perf dashboard ingest endpoint.
-while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc speed_subset speed_category extra_args; do
+while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc repetitions speed_subset speed_category extra_args; do
   [[ -z "$bname" ]] && continue
   run_vllm_bench "$CONTAINER" "$PORT" "$WORKLOAD_MODEL" \
                  "$bname" "$backend" "$dataset" "$isl" "$osl" "$nprompts" \
-                 "$conc" "$speed_subset" "$speed_category" "$extra_args" \
+                 "$conc" "$speed_subset" "$speed_category" "$repetitions" \
+                 "$extra_args" \
                  "$BENCH_TRUST_REMOTE_CODE" "$RESULTS_DIR"
 
   python3 "$DIR/ingest_perf.py" \

--- a/lib/run_vllm_bench.sh
+++ b/lib/run_vllm_bench.sh
@@ -5,7 +5,8 @@
 #   run_vllm_bench <container> <port> <model> <name> <backend> <dataset> \
 #                  <input_len> <output_len> <num_prompts> <max_concurrency> \
 #                  <speed_bench_dataset_subset> <speed_bench_category> \
-#                  <extra_args_base64> <trust_remote_code> <output_dir>
+#                  <repetitions> <extra_args_base64> <trust_remote_code> \
+#                  <output_dir>
 #
 # Docker runtime invokes `vllm bench serve` inside the vllm/vllm-openai
 # container via `docker exec`; native runtime invokes it directly. The raw
@@ -15,6 +16,7 @@
 # vLLM's SpeedBench class expects a local <subset>.jsonl file built by
 # NeMo's prepare.py — the bench CLI does not download the dataset itself.
 SPEED_BENCH_PREPARE_URL="https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py"
+RUN_VLLM_BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 pip_install_quiet() {
   if python3 -c 'import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)'; then
@@ -107,20 +109,43 @@ PY
   fi
 }
 
+validate_bench_result() {
+  local result_path=$1 expected=$2
+  python3 - "$result_path" "$expected" <<'PY'
+import json, sys
+path, expected = sys.argv[1], int(sys.argv[2])
+with open(path) as f:
+    result = json.load(f)
+def read_int(*keys, default=None):
+    for k in keys:
+        v = result.get(k)
+        if v is not None:
+            return int(v)
+    if default is not None:
+        return default
+    raise KeyError(keys[0])
+completed = read_int("completed", "successful", "successful_requests")
+failed = read_int("failed", "errored", "failed_requests", "num_failed_requests", default=0)
+if failed or completed != expected:
+    print(f"vllm bench serve incomplete: completed={completed} failed={failed} expected={expected}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
 run_vllm_bench() {
   local container=$1 port=$2 model=$3 name=$4 backend=$5 dataset=$6
   local input_len=$7 output_len=$8 num_prompts=$9 max_concurrency=${10}
   local speed_bench_dataset_subset=${11} speed_bench_category=${12}
-  local extra_args_base64=${13} trust_remote_code=${14} outdir=${15}
+  local repetitions=${13} extra_args_base64=${14} trust_remote_code=${15}
+  local outdir=${16}
   local runtime="${WORKLOAD_SERVER_RUNTIME:-docker}"
-  local in_container_json="/tmp/bench-${name}.json"
   local host_json="${outdir}/bench-${name}.json"
 
   [[ "$backend" == "-" ]] && backend=""
   [[ "$speed_bench_dataset_subset" == "-" ]] && speed_bench_dataset_subset=""
   [[ "$speed_bench_category" == "-" ]] && speed_bench_category=""
 
-  echo "--- :stopwatch: vllm bench serve ${name} (dataset=${dataset} isl=${input_len} osl=${output_len} conc=${max_concurrency} n=${num_prompts})"
+  echo "--- :stopwatch: vllm bench serve ${name} (dataset=${dataset} isl=${input_len} osl=${output_len} conc=${max_concurrency} n=${num_prompts} repetitions=${repetitions})"
   mkdir -p "$outdir"
 
   local cmd=(vllm bench serve)
@@ -172,34 +197,36 @@ run_vllm_bench() {
 
   append_bench_args "$extra_args_base64" cmd
 
-  if [[ "$runtime" == "native" ]]; then
-    cmd+=(--save-result --result-filename "$host_json")
-  else
-    cmd+=(--save-result --result-filename "$in_container_json")
+  local result_files=()
+  local repetition run_host_json run_container_json
+  for ((repetition = 1; repetition <= repetitions; repetition++)); do
+    if ((repetitions == 1)); then
+      run_host_json="$host_json"
+      run_container_json="/tmp/bench-${name}.json"
+    else
+      run_host_json="${outdir}/bench-${name}-run-${repetition}.json"
+      run_container_json="/tmp/bench-${name}-run-${repetition}.json"
+      echo "  repetition ${repetition}/${repetitions}"
+    fi
+
+    local run_cmd=("${cmd[@]}")
+    if [[ "$runtime" == "native" ]]; then
+      run_cmd+=(--save-result --result-filename "$run_host_json")
+    else
+      run_cmd+=(--save-result --result-filename "$run_container_json")
+    fi
+    "${run_cmd[@]}"
+
+    if [[ "$runtime" != "native" ]]; then
+      docker cp "${container}:${run_container_json}" "$run_host_json"
+    fi
+    validate_bench_result "$run_host_json" "$num_prompts"
+    result_files+=("$run_host_json")
+  done
+
+  if ((repetitions > 1)); then
+    python3 "$RUN_VLLM_BENCH_DIR/aggregate_perf.py" \
+      --output "$host_json" "${result_files[@]}"
   fi
-
-  "${cmd[@]}"
-
-  [[ "$runtime" != "native" ]] && docker cp "${container}:${in_container_json}" "$host_json"
-
-  python3 - "$host_json" "$num_prompts" <<'PY'
-import json, sys
-path, expected = sys.argv[1], int(sys.argv[2])
-with open(path) as f:
-    result = json.load(f)
-def read_int(*keys, default=None):
-    for k in keys:
-        v = result.get(k)
-        if v is not None:
-            return int(v)
-    if default is not None:
-        return default
-    raise KeyError(keys[0])
-completed = read_int("completed", "successful", "successful_requests")
-failed = read_int("failed", "errored", "failed_requests", "num_failed_requests", default=0)
-if failed or completed != expected:
-    print(f"vllm bench serve incomplete: completed={completed} failed={failed} expected={expected}", file=sys.stderr)
-    sys.exit(1)
-PY
   echo "  saved $host_json"
 }

--- a/workloads/deepseek_v4_pro_5_h200.yaml
+++ b/workloads/deepseek_v4_pro_5_h200.yaml
@@ -59,3 +59,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/gemma_4_31b_it_h200.yaml
+++ b/workloads/gemma_4_31b_it_h200.yaml
@@ -44,3 +44,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/glm_5_1_h200.yaml
+++ b/workloads/glm_5_1_h200.yaml
@@ -48,3 +48,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/gpt_oss_120b_h200.yaml
+++ b/workloads/gpt_oss_120b_h200.yaml
@@ -43,3 +43,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/kimi_k2_5_h200.yaml
+++ b/workloads/kimi_k2_5_h200.yaml
@@ -47,3 +47,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/minimax_m2_5_h200.yaml
+++ b/workloads/minimax_m2_5_h200.yaml
@@ -50,3 +50,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/nemotron_3_super_5_h200.yaml
+++ b/workloads/nemotron_3_super_5_h200.yaml
@@ -52,3 +52,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/qwen3_5_h200.yaml
+++ b/workloads/qwen3_5_h200.yaml
@@ -36,3 +36,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 256
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Why

H200 trend points currently come from one measured `vllm bench serve` invocation with no configured saturation warmup. That makes p99 TTFT especially sensitive to fresh-server kernel state, GPU clock ramp-up, and a handful of tail requests.

## What changed

- Add an odd-valued `repetitions` field to serving benchmark configs (default: 1).
- Run repeated benchmarks against the same server and retain every raw result.
- Median-aggregate numeric run-level metrics into the existing `bench-<name>.json` ingestion path.
- Configure every H200 workload for three repetitions and 128 warmup requests, matching the configured concurrency.
- Run CPU-only parser/aggregation regression tests before dynamic pipeline upload.
- Document the schema, output files, and warmup semantics.

Qwen3.5 remains at 256 measured prompts; this does not reintroduce the prompt-451 tokenizer failure fixed by #53.

## Impact

Each H200 result becomes the median of three fully warmed runs instead of a single cold-adjacent run. Individual `bench-<name>-run-<n>.json` files remain available as Buildkite artifacts for spread analysis.

This increases H200 benchmark GPU time because each repetition includes one 128-request warmup wave.

## Validation

- `python3 .buildkite/test_generate_pipeline.py` (6/6)
- `python3 .buildkite/test_benchmark_repetitions.py` (6/6)
- Parser smoke test for all eight H200 workloads
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`
- `shellcheck -s bash lib/run_vllm_bench.sh lib/run.sh`
- `python3 -m compileall -q lib .buildkite`
- `git diff --check`

GPU validation was not launched because perf-eval requires separate authorization before consuming shared GPU capacity.