### PR TITLE
Fix generate steps failure

### DIFF
--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -12,6 +12,8 @@ Image precedence: VLLM_IMAGE > VLLM_COMMIT > workload `vllm.image` >
 are not validated against the registry (because they will not run).
 """
 
+from __future__ import annotations
+
 import base64
 import json
 import os


### PR DESCRIPTION
The `generate steps` pipeline stage is failing on main after https://github.com/vllm-project/perf-eval/pull/59. example failure: 
https://buildkite.com/vllm/perf-eval/builds/407

```
[2026-08-10T21:49:26Z] Traceback (most recent call last):
[2026-08-10T21:49:26Z]   File "/var/lib/buildkite-agent/builds/bk-small-cpu-queue-premerge-i-075f3cb4e97bffd81-1/vllm/perf-eval/.buildkite/test_benchmark_repetitions.py", line 25, in <module>
[2026-08-10T21:49:26Z]     parse_workload = load_module("parse_workload", "lib/parse_workload.py")
[2026-08-10T21:49:26Z]   File "/var/lib/buildkite-agent/builds/bk-small-cpu-queue-premerge-i-075f3cb4e97bffd81-1/vllm/perf-eval/.buildkite/test_benchmark_repetitions.py", line 20, in load_module
[2026-08-10T21:49:26Z]     spec.loader.exec_module(module)
[2026-08-10T21:49:26Z]   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
[2026-08-10T21:49:26Z]   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
[2026-08-10T21:49:26Z]   File "/var/lib/buildkite-agent/builds/bk-small-cpu-queue-premerge-i-075f3cb4e97bffd81-1/vllm/perf-eval/lib/parse_workload.py", line 313, in <module>
[2026-08-10T21:49:26Z]     def max_test_cases_for_category(bfcl: dict, category: str) -> int | None:
[2026-08-10T21:49:26Z] TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

`int | None` is only evaluable at runtime on Python 3.10+. It appears the CPU agents that run `generate steps` are running Python 3.9. `from __future__ import annotations` makes every annotation in the file a lazily-stored string that is never evaluated, so the union is fine on 3.9.
