### PR TITLE
Add Kimi K3 standalone B300 perf workload

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -346,7 +346,9 @@ def make_step(path, data, profiles):
                     f"{path}: unknown docker_plugin {docker_kind!r}"
                     f" (have {', '.join(DOCKER_PLUGINS)})"
                 )
-        image = ecr_pull_through(resolved_image(data, profile))
+        image = resolved_image(data, profile)
+        if profile.get("ecr_pull_through_cache", True):
+            image = ecr_pull_through(image)
         step["plugins"] = [builder(image, data.get("num_gpus", 1), profile, gpu)]
     step_env = {
         k: os.environ[k]

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -114,6 +114,7 @@ def test_b300_profile_uses_standalone_docker_plugin():
     plugin = g.nvidia_docker_plugin("example/vllm:test", 8, profile, "B300")
     docker = plugin["docker#v5.2.0"]
     assert profile["queue"] == "b300-8"
+    assert profile["ecr_pull_through_cache"] is False
     assert docker["entrypoint"] == ""
     assert docker["shell"] == ["/bin/sh", "-e", "-c"]
     assert docker["propagate-uid-gid"] is True
@@ -147,6 +148,36 @@ def test_b300_workload_renders_docker_plugin_step():
     )
     assert step["agents"] == {"queue": "b300-8"}
     assert step["plugins"][0]["docker#v5.2.0"]["image"] == "example/vllm:test"
+
+
+def test_b300_public_ecr_image_bypasses_private_pull_through_cache():
+    image = (
+        "public.ecr.aws/q9t5s3a7/vllm-release-repo:"
+        "7ce42a9bb874a3491819807870e3efebde2845bd-x86_64"
+    )
+    previous = os.environ.get("VLLM_IMAGE")
+    os.environ["VLLM_IMAGE"] = image
+    try:
+        step = g.make_step(
+            "workloads/kimi_k3_b300.yaml",
+            {
+                "name": "kimi_k3-b300",
+                "gpu": "B300",
+                "num_gpus": 8,
+                "bench_only": True,
+                "vllm": {"model": "moonshotai/Kimi-K3"},
+                "vllm_bench": {"configs": []},
+            },
+            g.load_profiles(),
+        )
+    finally:
+        if previous is None:
+            os.environ.pop("VLLM_IMAGE", None)
+        else:
+            os.environ["VLLM_IMAGE"] = previous
+
+    docker = step["plugins"][0]["docker#v5.2.0"]
+    assert docker["image"] == image
 
 
 def test_kimi_k3_b300_uses_validated_launch_shape():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -149,6 +149,46 @@ def test_b300_workload_renders_docker_plugin_step():
     assert step["plugins"][0]["docker#v5.2.0"]["image"] == "example/vllm:test"
 
 
+def test_kimi_k3_b300_uses_validated_launch_shape():
+    path = os.path.join(os.path.dirname(HERE), "workloads", "kimi_k3_b300.yaml")
+    with open(path) as f:
+        data = g.yaml.safe_load(f)
+
+    step = g.make_step(path, data, g.load_profiles())
+    assert step["agents"] == {"queue": "b300-8"}
+    assert "docker#v5.2.0" in step["plugins"][0]
+    assert step["env"]["BENCH_ONLY"] == "1"
+
+    vllm = data["vllm"]
+    assert vllm["model"] == "moonshotai/Kimi-K3"
+    args = vllm["serve_args"]
+    for expected in (
+        "--tensor-parallel-size 8",
+        "--load-format fastsafetensors",
+        "--safetensors-load-strategy lazy",
+        "--language-model-only",
+        "--moe-backend marlin",
+        "--kv-cache-dtype fp8",
+        "--attention-backend FLASHINFER_MLA",
+        "--max-model-len 16384",
+        '"model":"Inferact/Kimi-K3-DSpark"',
+        '"num_speculative_tokens":7',
+    ):
+        assert expected in args
+
+    env = vllm["env"]
+    assert env["NCCL_DMABUF_ENABLE"] == 0
+    assert env["VLLM_ALLREDUCE_USE_FLASHINFER"] == 1
+    assert env["VLLM_USE_RUST_FRONTEND"] == 1
+    assert env["NCCL_NVLS_ENABLE"] == 1
+
+    metadata = data["vllm_bench"]["metadata"]
+    assert metadata == {"device": "b300", "tp": 8, "precision": "mxfp4"}
+    config = data["vllm_bench"]["configs"][0]
+    assert (config["input_len"], config["output_len"]) == (8192, 1024)
+    assert (config["num_prompts"], config["max_concurrency"]) == (256, 64)
+
+
 def test_glm_b300_vllm_uses_matched_real_spec_shape():
     path = os.path.join(
         os.path.dirname(HERE), "workloads", "glm_5_2_b200.yaml"

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -20,6 +20,9 @@ B300:
   hf_home: /raid/buildkite/hf-cache
   server_runtime: native
   docker_plugin: nvidia
+  # This standalone agent can pull public ECR directly but is not authenticated
+  # to the private AWS pull-through cache used by Kubernetes queues.
+  ecr_pull_through_cache: false
   # The standalone Axis host keeps validated framework images locally; avoid
   # re-pulling multi-gigabyte images on every opt-in benchmark invocation.
   always_pull: false

--- a/workloads/kimi_k3_b300.yaml
+++ b/workloads/kimi_k3_b300.yaml
@@ -1,0 +1,49 @@
+# Kimi K3 MXFP4 on one standalone 8xB300.
+# Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K3
+name: kimi_k3-b300
+gpu: B300
+num_gpus: 8
+nightly: false
+bench_only: true
+
+vllm:
+  model: moonshotai/Kimi-K3
+  startup_timeout: 3600
+  env:
+    NCCL_DMABUF_ENABLE: 0
+    VLLM_ALLREDUCE_USE_FLASHINFER: 1
+    VLLM_USE_RUST_FRONTEND: 1
+    NCCL_NVLS_ENABLE: 1
+  serve_args: >-
+    --tensor-parallel-size 8
+    --trust-remote-code
+    --load-format fastsafetensors
+    --safetensors-load-strategy lazy
+    --language-model-only
+    --enable-prefix-caching
+    --moe-backend marlin
+    --kv-cache-dtype fp8
+    --attention-backend FLASHINFER_MLA
+    --attention-config {"mla_prefill_backend":"FLASHINFER","use_prefill_query_quantization":true}
+    --max-model-len 16384
+    --max-num-seqs 512
+    --gpu-memory-utilization 0.90
+    --max-cudagraph-capture-size 256
+    --speculative-config {"model":"Inferact/Kimi-K3-DSpark","method":"dspark","num_speculative_tokens":7,"attention_backend":"FLASHINFER_MLA","draft_sample_method":"probabilistic","rejection_sample_method":"block"}
+
+vllm_bench:
+  metadata:
+    device: b300
+    tp: 8
+    precision: mxfp4
+  configs:
+    - name: 8k-in-1k-out-conc-64
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 256
+      max_concurrency: 64
+      args:
+        num_warmups: 64
+        disable_tqdm: true


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary

- Adds an opt-in `kimi_k3_b300` workload for the standalone 8×B300 runner.
- Reuses the B300 `docker#v5.2.0` profile from stacked PR #50 instead of duplicating that infrastructure.
- Uses the release-qualified TP8 Kimi K3 launch shape: DSpark-7, Marlin MXFP4 MoE, FlashInfer MLA, FP8 KV cache, prefix caching, and a 16K context limit.
- Adds an 8K-input / 1K-output, concurrency-64 `vllm bench serve` cell with 256 prompts.
- Keeps the workload opt-in and consumes `VLLM_IMAGE` at trigger time.

This does not duplicate PR #57: that PR adds an MI355X aiperf workload, while this change targets the standalone B300 queue and the existing vLLM bench ingestion path.

## Trigger

```text
WORKLOADS=kimi_k3_b300
VLLM_COMMIT=7ce42a9bb874a3491819807870e3efebde2845bd
VLLM_IMAGE=public.ecr.aws/q9t5s3a7/vllm-release-repo:7ce42a9bb874a3491819807870e3efebde2845bd-x86_64
```

## Validation

- `python3 .buildkite/test_generate_pipeline.py` — 11/11 passed
- Workload parser smoke passed
- Dynamic generation emitted queue `b300-8`, `docker#v5.2.0`, and the exact release-image override
- `bash -n` on the runner shell scripts
- Python compile checks for the generator, parser, and generator tests
- `git diff --check`

The Docker-plugin path itself previously passed on this runner in [perf-eval #393](https://buildkite.com/vllm/perf-eval/builds/393). Live Kimi validation is currently blocked by a host issue: [#411](https://buildkite.com/vllm/perf-eval/builds/411) shows host `nvidia-smi` timing out and a minimal GPU container failing with `nvidia-container-cli: ... driver rpc error: timed out`. After the B300 host is repaired, this PR still needs an end-to-end run against the image above, including confirmation that PR #50's FlashInfer cubin overlay matches the v0.27.1 image.