### PR TITLE
Authenticate perf and eval result ingestion

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -46,7 +46,9 @@ FULL_SETUP_COMMANDS = [setup_command("'lm-eval[api]' pyyaml")]
 BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml")]
 
 RUN_TEMPLATE = (
-    'export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$HOME/.local/bin:$PATH"'
+    'INGEST_BEARER_TOKEN="$(buildkite-agent secret get INGEST_BEARER_TOKEN)"'
+    " && export INGEST_BEARER_TOKEN"
+    ' && export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$HOME/.local/bin:$PATH"'
     " && ./lib/run.sh {path}"
 )
 

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -100,6 +100,13 @@ def test_shipped_amd_profiles_have_no_rootdisk_hostpath():
         )
 
 
+def test_run_command_fetches_ingest_token_before_workload():
+    command = g.RUN_TEMPLATE.format(path="workloads/example.yaml")
+    get_secret = "buildkite-agent secret get INGEST_BEARER_TOKEN"
+    assert get_secret in command
+    assert command.index(get_secret) < command.index("./lib/run.sh")
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ exec(open('lib/parse_workload.py').read())
 bash -n lib/run.sh && bash -n lib/server.sh && bash -n lib/run_lm_eval.sh
 ```
 
+**Ingestion auth and pipeline generation:**
+
+```bash
+python3 -m unittest discover -s tests -p 'test_ingest_auth.py'
+python3 .buildkite/test_generate_pipeline.py
+```
+
 If you actually need real validation (parser hitting lm-eval's task registry rather than a stub), `pip install 'lm-eval[api]' pyyaml` first. Without it the parser exits with `cannot validate task names: lm_eval not importable` — that's intentional, never silently skip validation.
 
 ## Launching a Buildkite build

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ The pipeline is [**`vllm/perf-eval`**](https://buildkite.com/vllm/perf-eval). Wi
 - `WORKLOADS` — comma- or newline-separated list of workload paths or stems. Runs exactly those instead of the default `nightly: true` set.
 - `NIGHTLY` — set to `1` to tag every ingested row with `nightly: true`. The dashboard's `/nightly` view filters on this to pair adjacent nightly builds; only the scheduled nightly cron should set it.
 
+Result uploads authenticate with `Authorization: Bearer ...`. Buildkite jobs
+retrieve `INGEST_BEARER_TOKEN` from the CI cluster's secret store immediately
+before running the workload; do not put the token in build environment settings
+or workload YAML. Local runs that upload results must export the same variable.
+
 **Example — trigger a build from the Buildkite UI:**
 
 1. Open the `vllm/perf-eval` pipeline → **New Build**.

--- a/lib/ingest.py
+++ b/lib/ingest.py
@@ -21,6 +21,7 @@ import urllib.request
 from pathlib import Path
 
 DEFAULT_ENDPOINT = "https://vllm-eval-data-ingest-224810116257.us-central1.run.app/"
+AUTH_TOKEN_ENV = "INGEST_BEARER_TOKEN"
 TIMEOUT = 30
 # Databricks Zerobus rejects records larger than 10 MiB and closes the stream.
 # Pack samples into batches that stay safely under that ceiling.
@@ -48,11 +49,17 @@ NIGHTLY_ENV = "NIGHTLY"
 
 
 def post(endpoint: str, payload: dict) -> None:
+    token = (os.environ.get(AUTH_TOKEN_ENV) or "").strip()
+    if not token:
+        raise RuntimeError(f"{AUTH_TOKEN_ENV} is required for result ingestion")
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         endpoint,
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:

--- a/lib/ingest_perf.py
+++ b/lib/ingest_perf.py
@@ -25,15 +25,23 @@ import urllib.error
 import urllib.request
 
 DEFAULT_ENDPOINT = "https://vllm-perf-data-ingest-224810116257.us-central1.run.app/"
+AUTH_TOKEN_ENV = "INGEST_BEARER_TOKEN"
 TIMEOUT = 30
 
 
 def post(endpoint: str, payload: dict) -> None:
+    token = (os.environ.get(AUTH_TOKEN_ENV) or "").strip()
+    if not token:
+        raise RuntimeError(f"{AUTH_TOKEN_ENV} is required for result ingestion")
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         endpoint,
         data=body,
-        headers={"Content-Type": "application/json", "X-Source": "perf-eval"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-Source": "perf-eval",
+        },
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:

--- a/tests/test_ingest_auth.py
+++ b/tests/test_ingest_auth.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Authentication regression tests for both ingestion clients."""
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class IngestAuthTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.modules = (
+            load_module("ingest", ROOT / "lib" / "ingest.py"),
+            load_module("ingest_perf", ROOT / "lib" / "ingest_perf.py"),
+        )
+
+    def test_bearer_header_is_sent(self):
+        for module in self.modules:
+            response = mock.MagicMock()
+            response.__enter__.return_value.status = 200
+            with self.subTest(module=module.__name__), mock.patch.dict(
+                os.environ, {module.AUTH_TOKEN_ENV: "test-token"}
+            ), mock.patch.object(
+                module.urllib.request, "urlopen", return_value=response
+            ) as urlopen:
+                module.post("https://ingest.example/", {"ok": True})
+                request = urlopen.call_args.args[0]
+                self.assertEqual(request.get_header("Authorization"), "Bearer test-token")
+
+    def test_missing_token_fails_before_network(self):
+        for module in self.modules:
+            with self.subTest(module=module.__name__), mock.patch.dict(
+                os.environ, {}, clear=True
+            ), mock.patch.object(module.urllib.request, "urlopen") as urlopen:
+                with self.assertRaisesRegex(RuntimeError, module.AUTH_TOKEN_ENV):
+                    module.post("https://ingest.example/", {"ok": True})
+                urlopen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- send the shared bearer token from both perf and eval upload clients
- retrieve `INGEST_BEARER_TOKEN` from the Buildkite CI cluster secret store immediately before each workload
- fail clearly before network access when the token is unavailable
- add client and generated-pipeline regression tests

## Validation

- `python3 -m unittest discover -s tests -p 'test_ingest_auth.py'`
- `python3 .buildkite/test_generate_pipeline.py`
- shell syntax checks for the workload helpers
- `git diff --check`

This PR was authored with assistance from Codex.