### PR TITLE
add more tests

### DIFF
--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -188,6 +188,22 @@ def test_long_b200_workloads_allow_one_hour_for_engine_startup():
         ), path
 
 
+def test_glm_b200_workloads_limit_cuda_graph_batch_size():
+    import yaml
+
+    workload_dir = os.path.join(ROOT, "workloads")
+    names = (
+        "glm_5_2_b200.yaml",
+        "glm_5_2_dspark_b200.yaml",
+    )
+    for name in names:
+        path = os.path.join(workload_dir, name)
+        with open(path) as f:
+            workload = yaml.safe_load(f)
+        serve_args = workload.get("vllm", {}).get("serve_args", "")
+        assert "--max-num-seqs 128" in serve_args, path
+
+
 def main():
     tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
     failed = 0

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -206,7 +206,7 @@ def test_glm_b200_workloads_limit_cuda_graph_batch_size():
             assert "--max-cudagraph-capture-size 128" in serve_args, path
 
 
-def test_glm_dspark_h200_uses_attention_compatible_kv_cache_dtype():
+def test_glm_dspark_h200_uses_compatible_kv_cache_config():
     import yaml
 
     path = os.path.join(ROOT, "workloads", "glm_5_2_dspark_h200.yaml")
@@ -214,6 +214,7 @@ def test_glm_dspark_h200_uses_attention_compatible_kv_cache_dtype():
         workload = yaml.safe_load(f)
     serve_args = workload.get("vllm", {}).get("serve_args", "")
     assert "--kv-cache-dtype bfloat16" in serve_args, path
+    assert "--max-model-len 32768" in serve_args, path
 
 
 def test_glm_h200_limits_model_length_to_fit_kv_cache():

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -220,11 +220,15 @@ def test_glm_dspark_h200_uses_compatible_kv_cache_config():
 def test_glm_h200_limits_model_length_to_fit_kv_cache():
     import yaml
 
-    path = os.path.join(ROOT, "workloads", "glm_5_2_h200.yaml")
-    with open(path) as f:
-        workload = yaml.safe_load(f)
-    serve_args = workload.get("vllm", {}).get("serve_args", "")
-    assert "--max-model-len 32768" in serve_args, path
+    for name in ("glm_5_2_h200.yaml", "glm_5_2_dspark_h200.yaml"):
+        path = os.path.join(ROOT, "workloads", name)
+        with open(path) as f:
+            workload = yaml.safe_load(f)
+        serve_args = workload.get("vllm", {}).get("serve_args", "")
+        assert "--max-model-len 32768" in serve_args, path
+        tasks = workload.get("lm_eval", {}).get("tasks", [])
+        gsm8k = next(task for task in tasks if task.get("name") == "gsm8k")
+        assert gsm8k.get("model_args", {}).get("max_gen_toks") == 8192, path
 
 
 def main():

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -206,6 +206,16 @@ def test_glm_b200_workloads_limit_cuda_graph_batch_size():
             assert "--max-cudagraph-capture-size 128" in serve_args, path
 
 
+def test_glm_dspark_h200_uses_attention_compatible_kv_cache_dtype():
+    import yaml
+
+    path = os.path.join(ROOT, "workloads", "glm_5_2_dspark_h200.yaml")
+    with open(path) as f:
+        workload = yaml.safe_load(f)
+    serve_args = workload.get("vllm", {}).get("serve_args", "")
+    assert "--kv-cache-dtype fp8_e4m3" in serve_args, path
+
+
 def main():
     tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
     failed = 0

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -202,6 +202,8 @@ def test_glm_b200_workloads_limit_cuda_graph_batch_size():
             workload = yaml.safe_load(f)
         serve_args = workload.get("vllm", {}).get("serve_args", "")
         assert "--max-num-seqs 128" in serve_args, path
+        if name == "glm_5_2_dspark_b200.yaml":
+            assert "--max-cudagraph-capture-size 128" in serve_args, path
 
 
 def main():

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -167,6 +167,27 @@ def test_long_workloads_allow_three_hours():
         assert workload.get("timeout_in_minutes") == 180, path
 
 
+def test_long_b200_workloads_allow_one_hour_for_engine_startup():
+    import yaml
+
+    workload_dir = os.path.join(ROOT, "workloads")
+    names = (
+        "deepseek_v4_flash_0731_b200.yaml",
+        "glm_5_2_b200.yaml",
+        "glm_5_2_dspark_b200.yaml",
+    )
+    for name in names:
+        path = os.path.join(workload_dir, name)
+        with open(path) as f:
+            workload = yaml.safe_load(f)
+        assert (
+            workload.get("vllm", {}).get("env", {}).get(
+                "VLLM_ENGINE_READY_TIMEOUT_S"
+            )
+            == 3600
+        ), path
+
+
 def main():
     tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
     failed = 0

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -213,7 +213,7 @@ def test_glm_dspark_h200_uses_attention_compatible_kv_cache_dtype():
     with open(path) as f:
         workload = yaml.safe_load(f)
     serve_args = workload.get("vllm", {}).get("serve_args", "")
-    assert "--kv-cache-dtype fp8_e4m3" in serve_args, path
+    assert "--kv-cache-dtype bfloat16" in serve_args, path
 
 
 def main():

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -216,6 +216,16 @@ def test_glm_dspark_h200_uses_attention_compatible_kv_cache_dtype():
     assert "--kv-cache-dtype bfloat16" in serve_args, path
 
 
+def test_glm_h200_limits_model_length_to_fit_kv_cache():
+    import yaml
+
+    path = os.path.join(ROOT, "workloads", "glm_5_2_h200.yaml")
+    with open(path) as f:
+        workload = yaml.safe_load(f)
+    serve_args = workload.get("vllm", {}).get("serve_args", "")
+    assert "--max-model-len 32768" in serve_args, path
+
+
 def main():
     tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
     failed = 0

--- a/workloads/deepseek_v4_flash_0731_b200.yaml
+++ b/workloads/deepseek_v4_flash_0731_b200.yaml
@@ -11,6 +11,7 @@ vllm:
     # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
     CUDA_HOME: /usr/local/cuda
     TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+    VLLM_ENGINE_READY_TIMEOUT_S: 3600
   serve_args: >-
     --tensor-parallel-size 2
     --data-parallel-size 4

--- a/workloads/deepseek_v4_flash_0731_b200.yaml
+++ b/workloads/deepseek_v4_flash_0731_b200.yaml
@@ -1,0 +1,50 @@
+# DeepSeek-V4-Flash-0731 on B200 (TP=2 × DP=4 + EP, deep_gemm_mega_moe, DSpark spec-decode)
+name: deepseek_v4_flash_0731-b200
+gpu: B200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: deepseek-ai/DeepSeek-V4-Flash-0731
+  env:
+    # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
+    CUDA_HOME: /usr/local/cuda
+    TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+  serve_args: >-
+    --tensor-parallel-size 2
+    --data-parallel-size 4
+    --enable-expert-parallel
+    --kv-cache-dtype fp8
+    --block-size 256
+    --moe-backend deep_gemm_mega_moe
+    --attention_config.use_fp4_indexer_cache=True
+    --tokenizer-mode deepseek_v4
+    --tool-call-parser deepseek_v4
+    --reasoning-parser deepseek_v4
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --speculative_config.method=dspark
+    --speculative_config.num_speculative_tokens=7
+    --speculative_config.draft_sample_method=probabilistic
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192

--- a/workloads/deepseek_v4_flash_0731_h200.yaml
+++ b/workloads/deepseek_v4_flash_0731_h200.yaml
@@ -1,0 +1,48 @@
+# DeepSeek-V4-Flash-0731 on H200 (TP=2 × DP=4 + EP, DSpark spec-decode)
+name: deepseek_v4_flash_0731-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: deepseek-ai/DeepSeek-V4-Flash-0731
+  env:
+    # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
+    CUDA_HOME: /usr/local/cuda
+    TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+  serve_args: >-
+    --tensor-parallel-size 2
+    --data-parallel-size 4
+    --enable-expert-parallel
+    --kv-cache-dtype fp8
+    --block-size 256
+    --tokenizer-mode deepseek_v4
+    --tool-call-parser deepseek_v4
+    --reasoning-parser deepseek_v4
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --speculative_config.method=dspark
+    --speculative_config.num_speculative_tokens=7
+    --speculative_config.draft_sample_method=probabilistic
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192

--- a/workloads/deepseek_v4_flash_h200.yaml
+++ b/workloads/deepseek_v4_flash_h200.yaml
@@ -1,0 +1,47 @@
+# DeepSeek-V4-Flash on H200 (TP=2 × DP=4 + EP, MTP spec-decode)
+name: deepseek_v4_flash-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: deepseek-ai/DeepSeek-V4-Flash
+  env:
+    # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
+    CUDA_HOME: /usr/local/cuda
+    TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+  serve_args: >-
+    --tensor-parallel-size 2
+    --data-parallel-size 4
+    --enable-expert-parallel
+    --kv-cache-dtype fp8
+    --block-size 256
+    --tokenizer-mode deepseek_v4
+    --tool-call-parser deepseek_v4
+    --reasoning-parser deepseek_v4
+    --enable-auto-tool-choice
+    --trust-remote-code
+    --speculative_config.method=mtp
+    --speculative_config.num_speculative_tokens=2
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 32768
+        max_gen_toks: 8192

--- a/workloads/glm_5_2_b200.yaml
+++ b/workloads/glm_5_2_b200.yaml
@@ -8,6 +8,8 @@ timeout_in_minutes: 180
 
 vllm:
   model: nvidia/GLM-5.2-NVFP4
+  env:
+    VLLM_ENGINE_READY_TIMEOUT_S: 3600
   serve_args: >-
     --tensor-parallel-size 8
     --enable-expert-parallel

--- a/workloads/glm_5_2_b200.yaml
+++ b/workloads/glm_5_2_b200.yaml
@@ -13,6 +13,7 @@ vllm:
   serve_args: >-
     --tensor-parallel-size 8
     --enable-expert-parallel
+    --max-num-seqs 128
     --kv-cache-dtype fp8_e4m3
     --tool-call-parser glm47
     --reasoning-parser glm45

--- a/workloads/glm_5_2_b200.yaml
+++ b/workloads/glm_5_2_b200.yaml
@@ -1,0 +1,52 @@
+# GLM-5.2 (NVFP4, modelopt re-quant) on B200 — TP=8 + EP, FP8 KV cache.
+# vLLM auto-detects the NVFP4 quantization from the checkpoint.
+name: glm_5_2-b200
+gpu: B200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: nvidia/GLM-5.2-NVFP4
+  serve_args: >-
+    --tensor-parallel-size 8
+    --enable-expert-parallel
+    --kv-cache-dtype fp8_e4m3
+    --tool-call-parser glm47
+    --reasoning-parser glm45
+    --enable-auto-tool-choice
+    --chat-template-content-format=string
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/glm_5_2_dspark_b200.yaml
+++ b/workloads/glm_5_2_dspark_b200.yaml
@@ -1,17 +1,19 @@
-# GLM-5.1 (FP8) on H200
-# Recipe recommends the glm51-cu130 image when CUDA >= 13.
-# MTP speculative decoding is part of the recommended config.
-name: glm_5_1-h200
-gpu: H200
+# GLM-5.2 (NVFP4, modelopt re-quant) on B200 with DSpark spec-decode
+# (RedHatAI speculator, 7 tokens). TP=8 + EP, FP8 KV cache
+name: glm_5_2_dspark-b200
+gpu: B200
 num_gpus: 8
 nightly: true
 
 vllm:
-  model: zai-org/GLM-5.1-FP8
+  model: nvidia/GLM-5.2-NVFP4
   serve_args: >-
     --tensor-parallel-size 8
-    --speculative-config.method mtp
-    --speculative-config.num_speculative_tokens 3
+    --enable-expert-parallel
+    --kv-cache-dtype fp8_e4m3
+    --speculative-config.method dspark
+    --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark
+    --speculative-config.num_speculative_tokens 7
     --tool-call-parser glm47
     --reasoning-parser glm45
     --enable-auto-tool-choice

--- a/workloads/glm_5_2_dspark_b200.yaml
+++ b/workloads/glm_5_2_dspark_b200.yaml
@@ -13,6 +13,7 @@ vllm:
   serve_args: >-
     --tensor-parallel-size 8
     --enable-expert-parallel
+    --max-num-seqs 128
     --kv-cache-dtype fp8_e4m3
     --speculative-config.method dspark
     --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark

--- a/workloads/glm_5_2_dspark_b200.yaml
+++ b/workloads/glm_5_2_dspark_b200.yaml
@@ -8,6 +8,8 @@ timeout_in_minutes: 180
 
 vllm:
   model: nvidia/GLM-5.2-NVFP4
+  env:
+    VLLM_ENGINE_READY_TIMEOUT_S: 3600
   serve_args: >-
     --tensor-parallel-size 8
     --enable-expert-parallel

--- a/workloads/glm_5_2_dspark_b200.yaml
+++ b/workloads/glm_5_2_dspark_b200.yaml
@@ -14,6 +14,7 @@ vllm:
     --tensor-parallel-size 8
     --enable-expert-parallel
     --max-num-seqs 128
+    --max-cudagraph-capture-size 128
     --kv-cache-dtype fp8_e4m3
     --speculative-config.method dspark
     --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark

--- a/workloads/glm_5_2_dspark_h200.yaml
+++ b/workloads/glm_5_2_dspark_h200.yaml
@@ -31,7 +31,7 @@ lm_eval:
       model_args:
         num_concurrent: 64
         max_length: 40960
-        max_gen_toks: 32768
+        max_gen_toks: 8192
 
 bfcl:
   test_categories:

--- a/workloads/glm_5_2_dspark_h200.yaml
+++ b/workloads/glm_5_2_dspark_h200.yaml
@@ -10,6 +10,7 @@ vllm:
   model: zai-org/GLM-5.2-FP8
   serve_args: >-
     --kv-cache-dtype bfloat16
+    --max-model-len 32768
     --tensor-parallel-size 8
     --speculative-config.method dspark
     --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark

--- a/workloads/glm_5_2_dspark_h200.yaml
+++ b/workloads/glm_5_2_dspark_h200.yaml
@@ -9,7 +9,7 @@ timeout_in_minutes: 180
 vllm:
   model: zai-org/GLM-5.2-FP8
   serve_args: >-
-    --kv-cache-dtype fp8
+    --kv-cache-dtype fp8_e4m3
     --tensor-parallel-size 8
     --speculative-config.method dspark
     --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark

--- a/workloads/glm_5_2_dspark_h200.yaml
+++ b/workloads/glm_5_2_dspark_h200.yaml
@@ -9,7 +9,7 @@ timeout_in_minutes: 180
 vllm:
   model: zai-org/GLM-5.2-FP8
   serve_args: >-
-    --kv-cache-dtype fp8_e4m3
+    --kv-cache-dtype bfloat16
     --tensor-parallel-size 8
     --speculative-config.method dspark
     --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark

--- a/workloads/glm_5_2_dspark_h200.yaml
+++ b/workloads/glm_5_2_dspark_h200.yaml
@@ -1,0 +1,54 @@
+# GLM-5.2 (FP8) on H200 with DSpark spec-decode (RedHatAI speculator, 7 tokens)
+
+name: glm_5_2_dspark-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: zai-org/GLM-5.2-FP8
+  serve_args: >-
+    --kv-cache-dtype fp8
+    --tensor-parallel-size 8
+    --speculative-config.method dspark
+    --speculative-config.model RedHatAI/GLM-5.2-speculator.dspark
+    --speculative-config.num_speculative_tokens 7
+    --tool-call-parser glm47
+    --reasoning-parser glm45
+    --enable-auto-tool-choice
+    --chat-template-content-format=string
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/glm_5_2_h200.yaml
+++ b/workloads/glm_5_2_h200.yaml
@@ -30,7 +30,7 @@ lm_eval:
       model_args:
         num_concurrent: 64
         max_length: 40960
-        max_gen_toks: 32768
+        max_gen_toks: 8192
 
 bfcl:
   test_categories:

--- a/workloads/glm_5_2_h200.yaml
+++ b/workloads/glm_5_2_h200.yaml
@@ -1,0 +1,53 @@
+# GLM-5.2 (FP8) on H200
+# MTP speculative decoding (5 draft tokens) is part of the recommended config.
+name: glm_5_2-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: zai-org/GLM-5.2-FP8
+  serve_args: >-
+    --kv-cache-dtype fp8
+    --tensor-parallel-size 8
+    --speculative-config.method mtp
+    --speculative-config.num_speculative_tokens 5
+    --tool-call-parser glm47
+    --reasoning-parser glm45
+    --enable-auto-tool-choice
+    --chat-template-content-format=string
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/glm_5_2_h200.yaml
+++ b/workloads/glm_5_2_h200.yaml
@@ -10,6 +10,7 @@ vllm:
   model: zai-org/GLM-5.2-FP8
   serve_args: >-
     --kv-cache-dtype fp8
+    --max-model-len 32768
     --tensor-parallel-size 8
     --speculative-config.method mtp
     --speculative-config.num_speculative_tokens 5


### PR DESCRIPTION
## Summary

- add DeepSeek V4 Flash and GLM 5.2 H200/B200 workloads
- allow three hours for every workload added or renamed by this PR
- cap the new DeepSeek server contexts at 32K

## Validation

- generated all seven dynamic Buildkite steps with `timeout_in_minutes: 180`
- validated the generated pipeline against the Buildkite schema
- passed parser smoke tests for all seven workloads
- passed repository regression tests and shell syntax checks

This PR was authored with assistance from Codex.
