### PR TITLE
Add `OMP_NUM_THREADS=1` Workaround for models timing out during weight loading

### DIFF
--- a/workloads/deepseek_v4_pro_mi355x.yaml
+++ b/workloads/deepseek_v4_pro_mi355x.yaml
@@ -8,6 +8,8 @@ vllm:
   model: deepseek-ai/DeepSeek-V4-Pro
   env:
     VLLM_ROCM_USE_AITER: 1
+    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
+    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --kv-cache-dtype fp8

--- a/workloads/kimi_k2_5_mi300x.yaml
+++ b/workloads/kimi_k2_5_mi300x.yaml
@@ -8,6 +8,8 @@ vllm:
   model: moonshotai/Kimi-K2.5
   env:
     VLLM_ROCM_USE_AITER: 1
+    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
+    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code

--- a/workloads/kimi_k2_5_mi355x.yaml
+++ b/workloads/kimi_k2_5_mi355x.yaml
@@ -8,6 +8,8 @@ vllm:
   model: moonshotai/Kimi-K2.5
   env:
     VLLM_ROCM_USE_AITER: 1
+    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
+    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code


### PR DESCRIPTION
Workaround for weight loading regression introduced by https://github.com/vllm-project/vllm/pull/49919. This PR will be reverted once we put in the proper fix in vllm.

E.g. DeepSeek-V4 on MI355 has been failing https://buildkite.com/vllm/perf-eval/builds/419/canvas?tab=output&jid=019ff9b5-ebfa-4dfa-a3c8-91629bea2acd#L501