### PR TITLE
[RFC] Capture reproducible experiment provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Each recipe is one `(model, hardware, set of tasks)` combination. The Buildkite 
 
 ```
 workloads/        one YAML per (model, hardware) recipe
-lib/              orchestrator (run.sh), helpers, GPU profiles
+lib/              orchestrator, provenance/replay tools, helpers, GPU profiles
 .buildkite/       pipeline bootstrap, step generator, and its tests
 CLAUDE.md         agent conventions and detailed Buildkite workflow
 ```
@@ -44,7 +44,12 @@ nightly: true            # include in the nightly schedule (default: false)
 
 vllm:                    # how the server is brought up
   model: Qwen/Qwen3.5-397B-A17B-FP8
-  image: vllm/vllm-openai:nightly      # optional; falls back to VLLM_IMAGE / VLLM_COMMIT / latest
+  image: vllm/vllm-openai:nightly      # optional unless build is set; falls back to overrides/latest
+  build:                                # optional; build a local image before the run
+    dockerfile: docker/Dockerfile
+    context: .
+    args:
+      CUDA_ARCH: "90"
   env:                                  # optional; merged over the GPU profile's env
     SOME_VAR: value
   serve_args: >-                        # appended to `vllm serve <model>`; word-split
@@ -93,6 +98,7 @@ vllm_bench:              # perf runs (optional) — fed to the perf dashboard
 A few things worth knowing:
 
 - **`gpu`** must match a key in `lib/gpu_profiles.yaml`. The profile sets the Buildkite queue, default image, HF cache path, and baseline env vars.
+- **`vllm.build` builds a local Docker image before the workload runs.** It requires an explicit `vllm.image` tag and Docker runtime, accepts `dockerfile`, `context`, and optional `args`, and cannot be combined with `VLLM_IMAGE` or `VLLM_COMMIT`. Paths are resolved from the command's working directory. Build-argument names containing token, secret, password, credential, or API-key terms are redacted from provenance; a replay that needs a redacted value stops and asks for a manually rebuilt image instead of silently changing the experiment.
 - **`nightly`** controls only the nightly schedule. Recipes with `nightly: false` (or omitted) are still triggerable explicitly via the `WORKLOADS` env var.
 - **`lm_eval.tasks` is a list** because each entry runs as a separate `lm_eval` invocation — `--num_fewshot` is a single global flag, so different shot counts need separate runs. Each task's results land in `results/<name>/<task-name>/`.
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
@@ -178,6 +184,33 @@ A real run needs a GPU host with Docker, vLLM, and lm-eval available:
 ```
 
 Locally, you can smoke-test recipe changes without a GPU — see `CLAUDE.md` for the parser stub and shell-syntax checks.
+
+### Experiment provenance and replay
+
+Every run writes a self-contained provenance bundle beside its results:
+
+```text
+results/<workload>/
+├── provenance/
+│   ├── manifest.json
+│   ├── workload.yaml
+│   └── docker/Dockerfile       # present when vllm.build was used
+├── bench-*.json
+├── <lm-eval-task>/
+└── bfcl-<category>/
+```
+
+The manifest records the exact workload and its checksum, resolved image ID and available repository digests, runtime, sanitized workload environment, and, for locally built images, the Dockerfile, sanitized build arguments, source repository, commit, build-context subdirectory, and `dirty` source-tree flag. Source patches and secret values are never captured. A dirty run remains usable, but the manifest explicitly marks that it cannot be reproduced exactly from the recorded commit alone.
+
+Buildkite already uploads `results/**/*`, so the bundle is retained with raw results. Both accuracy and performance ingestion payloads also include the same provenance object, allowing a database row to retain the experiment definition with its result.
+
+Replay a locally built experiment with:
+
+```bash
+./lib/replay.sh results/<workload>/provenance/manifest.json
+```
+
+Replay clones the recorded repository and commit, restores the recorded build-context subdirectory, builds the captured Dockerfile, and runs the captured workload. It warns for dirty source trees and refuses unattended replay when a required build argument was redacted.
 
 ## Agents
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ results/<workload>/
 └── bfcl-<category>/
 ```
 
-The manifest records the exact workload and its checksum, resolved image ID and available repository digests, runtime, sanitized workload environment, and, for locally built images, the Dockerfile, sanitized build arguments, source repository, commit, build-context subdirectory, and `dirty` source-tree flag. Source patches and secret values are never captured. A dirty run remains usable, but the manifest explicitly marks that it cannot be reproduced exactly from the recorded commit alone.
+The manifest records the exact workload and its checksum, resolved image ID and available repository digests, runtime, sanitized workload environment, and, for locally built images, the Dockerfile, sanitized build arguments, source repository, commit, and build-context subdirectory. Source patches, source-tree status, and secret values are never captured.
 
 Buildkite already uploads `results/**/*`, so the bundle is retained with raw results. Both accuracy and performance ingestion payloads also include the same provenance object, allowing a database row to retain the experiment definition with its result.
 
@@ -210,7 +210,7 @@ Replay a locally built experiment with:
 ./lib/replay.sh results/<workload>/provenance/manifest.json
 ```
 
-Replay clones the recorded repository and commit, restores the recorded build-context subdirectory, builds the captured Dockerfile, and runs the captured workload. It warns for dirty source trees and refuses unattended replay when a required build argument was redacted.
+Replay clones the recorded repository and commit, restores the recorded build-context subdirectory, builds the captured Dockerfile, and runs the captured workload. It refuses unattended replay when a required build argument was redacted.
 
 ## Agents
 

--- a/lib/ingest.py
+++ b/lib/ingest.py
@@ -46,6 +46,15 @@ VLLM_ENV_VARS = (
 # Set NIGHTLY=1 in the build env to mark rows as part of the nightly schedule.
 # The dashboard's /nightly view filters on this to pair adjacent nightlies.
 NIGHTLY_ENV = "NIGHTLY"
+PROVENANCE_ENV = "WORKLOAD_PROVENANCE_FILE"
+
+
+def load_provenance() -> dict | None:
+    path = (os.environ.get(PROVENANCE_ENV) or "").strip()
+    if not path:
+        return None
+    with open(path) as file:
+        return json.load(file)
 
 
 def post(endpoint: str, payload: dict) -> None:
@@ -79,6 +88,9 @@ def metadata(workload: str, task: str) -> dict:
             md[field] = v
     if os.environ.get(NIGHTLY_ENV) == "1":
         md["nightly"] = True
+    provenance = load_provenance()
+    if provenance:
+        md["provenance"] = provenance
     return md
 
 

--- a/lib/ingest_perf.py
+++ b/lib/ingest_perf.py
@@ -27,6 +27,15 @@ import urllib.request
 DEFAULT_ENDPOINT = "https://vllm-perf-data-ingest-224810116257.us-central1.run.app/"
 AUTH_TOKEN_ENV = "INGEST_BEARER_TOKEN"
 TIMEOUT = 30
+PROVENANCE_ENV = "WORKLOAD_PROVENANCE_FILE"
+
+
+def load_provenance() -> dict | None:
+    path = (os.environ.get(PROVENANCE_ENV) or "").strip()
+    if not path:
+        return None
+    with open(path) as file:
+        return json.load(file)
 
 
 def post(endpoint: str, payload: dict) -> None:
@@ -79,6 +88,9 @@ def transform(raw: dict, args: argparse.Namespace) -> dict:
 
     if os.environ.get("NIGHTLY") == "1":
         data["nightly"] = True
+    provenance = load_provenance()
+    if provenance:
+        data["provenance"] = provenance
 
     # Convert *_ms fields to seconds and emit interactivity (1000/tpot_ms).
     for key, value in raw.items():

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -43,6 +43,7 @@ BFCL_FIELDS = {
     "maximum_step_limit", "max_test_cases",
 }
 BFCL_DEFAULT_MAXIMUM_STEP_LIMIT = 10
+BUILD_FIELDS = {"dockerfile", "context", "args"}
 BFCL_KNOWN_CATEGORIES = {
     "simple_python", "simple_java", "simple_javascript",
     "multiple", "parallel", "parallel_multiple", "irrelevance",
@@ -122,6 +123,35 @@ def resolve_image(vllm: dict, profile: dict) -> tuple[str, str]:
 
     image = vllm.get("image", f"{repo}:nightly")
     return image, commit_from_image(str(image))
+
+
+def validate_build(vllm: dict, profile: dict, path: str) -> dict:
+    build = vllm.get("build") or {}
+    if not build:
+        return {}
+    if not isinstance(build, dict):
+        sys.exit(f"{path}: vllm.build must be a map")
+    extra = set(build) - BUILD_FIELDS
+    if extra:
+        sys.exit(f"{path}: vllm.build has unsupported fields {sorted(extra)}")
+    if not vllm.get("image"):
+        sys.exit(f"{path}: vllm.build requires an explicit vllm.image tag")
+    if os.environ.get("VLLM_IMAGE") or os.environ.get("VLLM_COMMIT"):
+        sys.exit(f"{path}: vllm.build cannot be combined with VLLM_IMAGE or VLLM_COMMIT")
+    if profile.get("server_runtime", "docker") != "docker":
+        sys.exit(f"{path}: vllm.build requires a docker server runtime")
+    dockerfile = build.get("dockerfile")
+    context = build.get("context", ".")
+    args = build.get("args") or {}
+    if not isinstance(dockerfile, str) or not dockerfile.strip():
+        sys.exit(f"{path}: vllm.build.dockerfile must be a non-empty path")
+    if not isinstance(context, str) or not context.strip():
+        sys.exit(f"{path}: vllm.build.context must be a non-empty path")
+    if not isinstance(args, dict):
+        sys.exit(f"{path}: vllm.build.args must be a map")
+    if any(not isinstance(name, str) or not name for name in args):
+        sys.exit(f"{path}: vllm.build.args keys must be non-empty strings")
+    return {"dockerfile": dockerfile, "context": context, "args": args}
 
 
 def parse_tp(serve_args: str) -> int:
@@ -421,6 +451,7 @@ def main(path: str) -> None:
     serve_args = vllm.get("serve_args") or ""
     if bfcl:
         validate_bfcl(bfcl, serve_args, path)
+    build = validate_build(vllm, profile, path)
 
     image, vllm_commit = resolve_image(vllm, profile)
     env = {**(profile.get("env") or {}), **(vllm.get("env") or {})}
@@ -438,6 +469,9 @@ def main(path: str) -> None:
     emit("MODEL", vllm.get("model", ""))
     emit("SERVE_ARGS", serve_args)
     emit("SERVER_RUNTIME", profile.get("server_runtime", "docker"))
+    emit("BUILD_DOCKERFILE", build.get("dockerfile", ""))
+    emit("BUILD_CONTEXT", build.get("context", ""))
+    emit("BUILD_ARGS_JSON", json.dumps(build.get("args", {}), separators=(",", ":")))
     emit("ENV", "\n".join(f"{k}={fmt(v)}" for k, v in env.items()))
     emit("LM_EVAL_TASKS_TSV", task_tsv(tasks, lm_eval.get("model_args") or {}))
     emit("VLLM_BENCH_TSV", bench_tsv(bench_configs, path))

--- a/lib/provenance.py
+++ b/lib/provenance.py
@@ -28,7 +28,6 @@ def source_metadata(path: Path) -> dict:
     try:
         repository = run_git(path, "config", "--get", "remote.origin.url").strip()
         commit = run_git(path, "rev-parse", "HEAD").strip()
-        dirty = bool(run_git(path, "status", "--porcelain").strip())
         root = Path(run_git(path, "rev-parse", "--show-toplevel").strip())
         subdirectory = str(path.resolve().relative_to(root.resolve()))
     except (subprocess.CalledProcessError, ValueError) as error:
@@ -36,7 +35,6 @@ def source_metadata(path: Path) -> dict:
     return {
         "repository": repository,
         "commit": commit,
-        "dirty": dirty,
         "context_subdirectory": subdirectory or ".",
     }
 

--- a/lib/provenance.py
+++ b/lib/provenance.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+SENSITIVE_NAME = re.compile(r"(?:token|secret|password|passwd|api[_-]?key|credential)", re.IGNORECASE)
+
+
+def run_git(path: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ).stdout
+
+
+def source_metadata(path: Path) -> dict:
+    try:
+        repository = run_git(path, "config", "--get", "remote.origin.url").strip()
+        commit = run_git(path, "rev-parse", "HEAD").strip()
+        dirty = bool(run_git(path, "status", "--porcelain").strip())
+        root = Path(run_git(path, "rev-parse", "--show-toplevel").strip())
+        subdirectory = str(path.resolve().relative_to(root.resolve()))
+    except (subprocess.CalledProcessError, ValueError) as error:
+        raise RuntimeError(f"build context is not a readable git repository: {path}") from error
+    return {
+        "repository": repository,
+        "commit": commit,
+        "dirty": dirty,
+        "context_subdirectory": subdirectory or ".",
+    }
+
+
+def sanitize_build_args(build_args: dict) -> dict:
+    return {
+        str(name): "<redacted>" if SENSITIVE_NAME.search(str(name)) else value
+        for name, value in build_args.items()
+    }
+
+
+def sanitize_environment(environment: str) -> dict:
+    values = {}
+    for entry in environment.splitlines():
+        if not entry:
+            continue
+        name, separator, value = entry.partition("=")
+        if not separator:
+            continue
+        values[name] = "<redacted>" if SENSITIVE_NAME.search(name) else value
+    return values
+
+
+def file_record(path: Path) -> dict:
+    content = path.read_text()
+    return {
+        "content": content,
+        "sha256": hashlib.sha256(content.encode()).hexdigest(),
+    }
+
+
+def image_metadata(image: str, image_id: str = "", runtime: str = "docker") -> dict:
+    if runtime != "docker":
+        return {"reference": image, "id": image_id, "repo_digests": []}
+    inspect_command = [
+        "docker", "image", "inspect", image, "--format", "{{json .RepoDigests}}"
+    ]
+    result = subprocess.run(
+        inspect_command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        subprocess.run(["docker", "pull", image], check=True)
+        result = subprocess.run(
+            inspect_command,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+    digests = json.loads(result.stdout)
+    if not image_id:
+        image_id = subprocess.run(
+            ["docker", "image", "inspect", image, "--format", "{{.Id}}"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+    return {"reference": image, "id": image_id, "repo_digests": digests}
+
+
+def build_image(image: str, dockerfile: Path, context: Path, build_args: dict) -> str:
+    command = ["docker", "build", "--tag", image, "--file", str(dockerfile)]
+    for name, value in build_args.items():
+        command.extend(["--build-arg", f"{name}={value}"])
+    command.append(str(context))
+    subprocess.run(command, check=True, stdout=sys.stderr)
+    return subprocess.run(
+        ["docker", "image", "inspect", image, "--format", "{{.Id}}"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def capture(
+    workload: Path,
+    results_dir: Path,
+    image: str,
+    image_id: str,
+    dockerfile: Path | None,
+    build_context: Path | None,
+    build_args: dict,
+    runtime: str,
+    environment: str = "",
+) -> Path:
+    provenance_dir = results_dir / "provenance"
+    docker_dir = provenance_dir / "docker"
+    provenance_dir.mkdir(parents=True, exist_ok=True)
+    if docker_dir.exists():
+        shutil.rmtree(docker_dir)
+    workload_copy = provenance_dir / "workload.yaml"
+    shutil.copyfile(workload, workload_copy)
+
+    manifest = {
+        "schema_version": 1,
+        "workload": {"path": "workload.yaml", **file_record(workload_copy)},
+        "image": image_metadata(image, image_id, runtime),
+        "runtime": runtime,
+        "environment": sanitize_environment(environment),
+    }
+    if dockerfile is not None and build_context is not None:
+        docker_dir.mkdir(parents=True, exist_ok=True)
+        dockerfile_copy = docker_dir / "Dockerfile"
+        shutil.copyfile(dockerfile, dockerfile_copy)
+        manifest["build"] = {
+            "dockerfile": "docker/Dockerfile",
+            "dockerfile_record": file_record(dockerfile_copy),
+            "args": sanitize_build_args(build_args),
+        }
+        manifest["source"] = source_metadata(build_context)
+
+    manifest_path = provenance_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest_path
+
+
+def parse_json_map(value: str) -> dict:
+    parsed = json.loads(value or "{}")
+    if not isinstance(parsed, dict):
+        raise ValueError("build args must be a JSON object")
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser("build")
+    build_parser.add_argument("--image", required=True)
+    build_parser.add_argument("--dockerfile", required=True, type=Path)
+    build_parser.add_argument("--context", required=True, type=Path)
+    build_parser.add_argument("--args-json", default="{}")
+
+    capture_parser = subparsers.add_parser("capture")
+    capture_parser.add_argument("--workload", required=True, type=Path)
+    capture_parser.add_argument("--results-dir", required=True, type=Path)
+    capture_parser.add_argument("--image", required=True)
+    capture_parser.add_argument("--image-id", default="")
+    capture_parser.add_argument("--dockerfile", type=Path)
+    capture_parser.add_argument("--context", type=Path)
+    capture_parser.add_argument("--args-json", default="{}")
+    capture_parser.add_argument("--runtime", required=True)
+    capture_parser.add_argument("--environment", default="")
+
+    args = parser.parse_args()
+    try:
+        build_args = parse_json_map(args.args_json)
+        if args.command == "build":
+            print(build_image(args.image, args.dockerfile, args.context, build_args))
+        else:
+            print(
+                capture(
+                    args.workload,
+                    args.results_dir,
+                    args.image,
+                    args.image_id,
+                    args.dockerfile,
+                    args.context,
+                    build_args,
+                    args.runtime,
+                    args.environment,
+                )
+            )
+    except (OSError, ValueError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"provenance: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/replay.sh
+++ b/lib/replay.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST="${1:?usage: $0 <provenance/manifest.json>}"
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 2; }
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROVENANCE_DIR="$(cd "$(dirname "$MANIFEST")" && pwd)"
+readarray -t FIELDS < <(python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as file:
+    manifest = json.load(file)
+source = manifest.get("source") or {}
+build = manifest.get("build") or {}
+print(source.get("repository", ""))
+print(source.get("commit", ""))
+print("1" if source.get("dirty") else "0")
+print(json.dumps(build.get("args") or {}, separators=(",", ":")))
+print(source.get("context_subdirectory", "."))
+PY
+)
+REPOSITORY="${FIELDS[0]}"
+COMMIT="${FIELDS[1]}"
+DIRTY="${FIELDS[2]}"
+BUILD_ARGS_JSON="${FIELDS[3]}"
+CONTEXT_SUBDIRECTORY="${FIELDS[4]}"
+
+[[ -n "$REPOSITORY" && -n "$COMMIT" ]] || {
+  echo "manifest does not contain build source metadata" >&2
+  exit 2
+}
+if [[ "$DIRTY" == "1" ]]; then
+  echo "warning: the original source tree was dirty; this replay may not match it exactly" >&2
+fi
+if [[ "$BUILD_ARGS_JSON" == *'"<redacted>"'* ]]; then
+  echo "manifest contains redacted build arguments and cannot be replayed unattended" >&2
+  exit 2
+fi
+
+REPLAY_DIR="$(mktemp -d)"
+trap 'rm -rf "$REPLAY_DIR"' EXIT
+git clone --no-checkout "$REPOSITORY" "$REPLAY_DIR/source"
+git -C "$REPLAY_DIR/source" checkout --detach "$COMMIT"
+BUILD_CONTEXT="$REPLAY_DIR/source"
+if [[ "$CONTEXT_SUBDIRECTORY" != "." ]]; then
+  BUILD_CONTEXT="${BUILD_CONTEXT}/${CONTEXT_SUBDIRECTORY}"
+fi
+[[ -d "$BUILD_CONTEXT" ]] || { echo "recorded build context not found: $BUILD_CONTEXT" >&2; exit 2; }
+IMAGE="perf-eval-replay:${COMMIT:0:12}"
+python3 "$DIR/provenance.py" build \
+  --image "$IMAGE" \
+  --dockerfile "$PROVENANCE_DIR/docker/Dockerfile" \
+  --context "$BUILD_CONTEXT" \
+  --args-json "$BUILD_ARGS_JSON" >/dev/null
+REPLAY_WORKLOAD="$REPLAY_DIR/workload.yaml"
+python3 - "$PROVENANCE_DIR/workload.yaml" "$REPLAY_WORKLOAD" "$IMAGE" <<'PY'
+import sys
+import yaml
+
+with open(sys.argv[1]) as file:
+    workload = yaml.safe_load(file)
+workload["vllm"].pop("build", None)
+workload["vllm"]["image"] = sys.argv[3]
+with open(sys.argv[2], "w") as file:
+    yaml.safe_dump(workload, file, sort_keys=False)
+PY
+"$DIR/run.sh" "$REPLAY_WORKLOAD"

--- a/lib/replay.sh
+++ b/lib/replay.sh
@@ -16,24 +16,19 @@ source = manifest.get("source") or {}
 build = manifest.get("build") or {}
 print(source.get("repository", ""))
 print(source.get("commit", ""))
-print("1" if source.get("dirty") else "0")
 print(json.dumps(build.get("args") or {}, separators=(",", ":")))
 print(source.get("context_subdirectory", "."))
 PY
 )
 REPOSITORY="${FIELDS[0]}"
 COMMIT="${FIELDS[1]}"
-DIRTY="${FIELDS[2]}"
-BUILD_ARGS_JSON="${FIELDS[3]}"
-CONTEXT_SUBDIRECTORY="${FIELDS[4]}"
+BUILD_ARGS_JSON="${FIELDS[2]}"
+CONTEXT_SUBDIRECTORY="${FIELDS[3]}"
 
 [[ -n "$REPOSITORY" && -n "$COMMIT" ]] || {
   echo "manifest does not contain build source metadata" >&2
   exit 2
 }
-if [[ "$DIRTY" == "1" ]]; then
-  echo "warning: the original source tree was dirty; this replay may not match it exactly" >&2
-fi
 if [[ "$BUILD_ARGS_JSON" == *'"<redacted>"'* ]]; then
   echo "manifest contains redacted build arguments and cannot be replayed unattended" >&2
   exit 2

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -30,6 +30,39 @@ if [[ "$WORKLOAD_SERVE_ARGS" =~ (^|[[:space:]])--trust-remote-code([[:space:]]|$
 fi
 mkdir -p "$RESULTS_DIR"
 
+BUILD_IMAGE_ID=""
+PROVENANCE_ARGS=(
+  capture
+  --workload "$WORKLOAD"
+  --results-dir "$RESULTS_DIR"
+  --image "$WORKLOAD_IMAGE"
+  --runtime "$WORKLOAD_SERVER_RUNTIME"
+  --environment "$WORKLOAD_ENV"
+)
+if [[ -n "$WORKLOAD_BUILD_DOCKERFILE" ]]; then
+  BUILD_CONTEXT="$(realpath "$WORKLOAD_BUILD_CONTEXT")"
+  BUILD_DOCKERFILE="$WORKLOAD_BUILD_DOCKERFILE"
+  if [[ "$BUILD_DOCKERFILE" != /* ]]; then
+    BUILD_DOCKERFILE="${BUILD_CONTEXT}/${BUILD_DOCKERFILE}"
+  fi
+  [[ -d "$BUILD_CONTEXT" ]] || { echo "build context not found: $BUILD_CONTEXT" >&2; exit 2; }
+  [[ -f "$BUILD_DOCKERFILE" ]] || { echo "Dockerfile not found: $BUILD_DOCKERFILE" >&2; exit 2; }
+  BUILD_IMAGE_ID="$(python3 "$DIR/provenance.py" build \
+    --image "$WORKLOAD_IMAGE" \
+    --dockerfile "$BUILD_DOCKERFILE" \
+    --context "$BUILD_CONTEXT" \
+    --args-json "$WORKLOAD_BUILD_ARGS_JSON")"
+  PROVENANCE_ARGS+=(
+    --image-id "$BUILD_IMAGE_ID"
+    --dockerfile "$BUILD_DOCKERFILE"
+    --context "$BUILD_CONTEXT"
+    --args-json "$WORKLOAD_BUILD_ARGS_JSON"
+  )
+fi
+python3 "$DIR/provenance.py" "${PROVENANCE_ARGS[@]}"
+WORKLOAD_PROVENANCE_FILE="${RESULTS_DIR}/provenance/manifest.json"
+export WORKLOAD_PROVENANCE_FILE
+
 trap 'stop_server "$CONTAINER"' EXIT
 
 start_server "$CONTAINER" "$PORT" "$WORKLOAD_IMAGE" "$WORKLOAD_MODEL" \

--- a/tests/test_ingest_auth.py
+++ b/tests/test_ingest_auth.py
@@ -2,7 +2,9 @@
 """Authentication regression tests for both ingestion clients."""
 
 import importlib.util
+import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -47,6 +49,16 @@ class IngestAuthTests(unittest.TestCase):
                 with self.assertRaisesRegex(RuntimeError, module.AUTH_TOKEN_ENV):
                     module.post("https://ingest.example/", {"ok": True})
                 urlopen.assert_not_called()
+
+    def test_provenance_is_loaded_from_run_manifest(self):
+        expected = {"schema_version": 1, "source": {"dirty": True}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            path.write_text(json.dumps(expected))
+            with mock.patch.dict(os.environ, {"WORKLOAD_PROVENANCE_FILE": str(path)}):
+                for module in self.modules:
+                    with self.subTest(module=module.__name__):
+                        self.assertEqual(module.load_provenance(), expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ProvenanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.provenance = load_module("provenance", ROOT / "lib" / "provenance.py")
+
+    def test_source_metadata_records_clean_state_without_diff(self):
+        completed = {
+            ("config", "--get", "remote.origin.url"): "git@example.test:vllm.git\n",
+            ("rev-parse", "HEAD"): "abc123\n",
+            ("status", "--porcelain"): " M vllm/config.py\n",
+            ("rev-parse", "--show-toplevel"): "/src\n",
+        }
+
+        def run_git(path, *args):
+            return completed[args]
+
+        with mock.patch.object(self.provenance, "run_git", side_effect=run_git):
+            source = self.provenance.source_metadata(Path("/src/vllm"))
+
+        self.assertEqual(source["repository"], "git@example.test:vllm.git")
+        self.assertEqual(source["commit"], "abc123")
+        self.assertTrue(source["dirty"])
+        self.assertNotIn("diff", source)
+
+    def test_native_image_metadata_does_not_require_docker(self):
+        with mock.patch.object(self.provenance.subprocess, "run") as run:
+            metadata = self.provenance.image_metadata("registry/image:tag", runtime="native")
+        self.assertEqual(metadata, {"reference": "registry/image:tag", "id": "", "repo_digests": []})
+        run.assert_not_called()
+
+    def test_build_image_stdout_contains_only_image_id(self):
+        completed = [mock.Mock(stdout=""), mock.Mock(stdout="sha256:123\n")]
+        with mock.patch.object(
+            self.provenance.subprocess, "run", side_effect=completed
+        ) as run:
+            image_id = self.provenance.build_image(
+                "local/test:dev", Path("Dockerfile"), Path("."), {}
+            )
+        self.assertEqual(image_id, "sha256:123")
+        self.assertIs(run.call_args_list[0].kwargs["stdout"], self.provenance.sys.stderr)
+
+    def test_sensitive_build_args_are_redacted(self):
+        sanitized = self.provenance.sanitize_build_args(
+            {"CUDA_ARCH": "90", "HF_TOKEN": "secret", "api-key": "secret"}
+        )
+        self.assertEqual(sanitized["CUDA_ARCH"], "90")
+        self.assertEqual(sanitized["HF_TOKEN"], "<redacted>")
+        self.assertEqual(sanitized["api-key"], "<redacted>")
+
+    def test_manifest_copies_inputs_and_is_self_contained(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload.yaml"
+            dockerfile = root / "Dockerfile.custom"
+            results = root / "results"
+            workload.write_text("name: test\n")
+            dockerfile.write_text("FROM scratch\n")
+            with mock.patch.object(
+                self.provenance,
+                "source_metadata",
+                return_value={"repository": "repo", "commit": "abc", "dirty": False},
+            ), mock.patch.object(
+                self.provenance,
+                "image_metadata",
+                return_value={
+                    "reference": "local/test:dev",
+                    "id": "sha256:123",
+                    "repo_digests": [],
+                },
+            ):
+                manifest_path = self.provenance.capture(
+                    workload=workload,
+                    results_dir=results,
+                    image="local/test:dev",
+                    image_id="sha256:123",
+                    dockerfile=dockerfile,
+                    build_context=root,
+                    build_args={"MODE": "dev"},
+                    runtime="docker",
+                    environment="CUDA_VISIBLE_DEVICES=0\nHF_TOKEN=secret",
+                )
+
+            manifest = json.loads(manifest_path.read_text())
+            self.assertEqual(manifest["schema_version"], 1)
+            self.assertEqual(manifest["image"]["id"], "sha256:123")
+            self.assertEqual(manifest["source"]["dirty"], False)
+            self.assertEqual(manifest["environment"]["CUDA_VISIBLE_DEVICES"], "0")
+            self.assertEqual(manifest["environment"]["HF_TOKEN"], "<redacted>")
+            self.assertEqual(manifest["build"]["dockerfile"], "docker/Dockerfile")
+            self.assertEqual((results / "provenance" / "workload.yaml").read_text(), "name: test\n")
+            self.assertEqual(
+                (results / "provenance" / "docker" / "Dockerfile").read_text(),
+                "FROM scratch\n",
+            )
+
+
+class ParserBuildTests(unittest.TestCase):
+    def run_parser(self, workload: dict, extra_env=None):
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            path = Path(tmp) / "workload.yaml"
+            path.write_text(yaml.safe_dump(workload))
+            env = {**os.environ, "BENCH_ONLY": "1", **(extra_env or {})}
+            return subprocess.run(
+                ["python3", str(ROOT / "lib" / "parse_workload.py"), str(path)],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+    def workload(self):
+        return {
+            "name": "local-build",
+            "gpu": "H200",
+            "vllm": {
+                "model": "example/model",
+                "image": "local/vllm:test",
+                "build": {
+                    "dockerfile": "Dockerfile",
+                    "context": ".",
+                    "args": {"CUDA_ARCH": "90"},
+                },
+            },
+            "vllm_bench": {
+                "configs": [
+                    {
+                        "name": "smoke",
+                        "input_len": 1,
+                        "output_len": 1,
+                        "num_prompts": 1,
+                        "max_concurrency": 1,
+                    }
+                ]
+            },
+        }
+
+    def test_build_config_is_exported(self):
+        result = self.run_parser(self.workload())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("WORKLOAD_BUILD_DOCKERFILE=", result.stdout)
+        self.assertIn("WORKLOAD_BUILD_CONTEXT=", result.stdout)
+        self.assertIn("WORKLOAD_BUILD_ARGS_JSON=", result.stdout)
+
+    def test_build_requires_explicit_image_tag(self):
+        workload = self.workload()
+        del workload["vllm"]["image"]
+        result = self.run_parser(workload)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("vllm.image", result.stderr)
+
+    def test_build_rejects_image_override(self):
+        result = self.run_parser(self.workload(), {"VLLM_IMAGE": "override:test"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot be combined", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -27,11 +27,10 @@ class ProvenanceTests(unittest.TestCase):
     def setUpClass(cls):
         cls.provenance = load_module("provenance", ROOT / "lib" / "provenance.py")
 
-    def test_source_metadata_records_clean_state_without_diff(self):
+    def test_source_metadata_records_repository_without_inspecting_worktree(self):
         completed = {
             ("config", "--get", "remote.origin.url"): "git@example.test:vllm.git\n",
             ("rev-parse", "HEAD"): "abc123\n",
-            ("status", "--porcelain"): " M vllm/config.py\n",
             ("rev-parse", "--show-toplevel"): "/src\n",
         }
 
@@ -43,8 +42,8 @@ class ProvenanceTests(unittest.TestCase):
 
         self.assertEqual(source["repository"], "git@example.test:vllm.git")
         self.assertEqual(source["commit"], "abc123")
-        self.assertTrue(source["dirty"])
-        self.assertNotIn("diff", source)
+        self.assertEqual(source["context_subdirectory"], "vllm")
+        self.assertNotIn("dirty", source)
 
     def test_native_image_metadata_does_not_require_docker(self):
         with mock.patch.object(self.provenance.subprocess, "run") as run:
@@ -82,7 +81,7 @@ class ProvenanceTests(unittest.TestCase):
             with mock.patch.object(
                 self.provenance,
                 "source_metadata",
-                return_value={"repository": "repo", "commit": "abc", "dirty": False},
+                return_value={"repository": "repo", "commit": "abc"},
             ), mock.patch.object(
                 self.provenance,
                 "image_metadata",
@@ -107,7 +106,7 @@ class ProvenanceTests(unittest.TestCase):
             manifest = json.loads(manifest_path.read_text())
             self.assertEqual(manifest["schema_version"], 1)
             self.assertEqual(manifest["image"]["id"], "sha256:123")
-            self.assertEqual(manifest["source"]["dirty"], False)
+            self.assertNotIn("dirty", manifest["source"])
             self.assertEqual(manifest["environment"]["CUDA_VISIBLE_DEVICES"], "0")
             self.assertEqual(manifest["environment"]["HF_TOKEN"], "<redacted>")
             self.assertEqual(manifest["build"]["dockerfile"], "docker/Dockerfile")


### PR DESCRIPTION
# Adding Dockerfile Records for Reproducibility

:construction: WIP, I'm marking this as a draft until I do a bit more local testing with this.

I've been using perf-eval a lot to help manage my local benchmarking efforts. One thing that I often wish I had was the ability to capture the dockerfile when using a custom local dockerfile (e.g. assessing performance of several stacked PRs before they're merged). My hope is that if we can bundle the dockerfile, yaml config used to drive perf-eval, and the json outputs, then we have a totally reproducible bundle that's easy to story and reference in a database.

If this is out of scope for what you envisioned for the project, just lmk!

## Proposed Changes

Added optional local Docker image builds to workload YAML, captured a self-contained provenance bundle with workload, Dockerfile, image identity, source repository/commit/dirty state, and sanitized settings, attached provenance to both ingestion formats, and added manifest-driven replay.

## Tests

- Python unit tests: 11 passed
- Buildkite pipeline generation tests: 7 passed
- Benchmark repetition tests: 6 passed
- Shell syntax checks: passed
- Whitespace validation: passed
