### PR TITLE
Raise timeout for long H200 workloads

### DIFF
--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -145,6 +145,22 @@ def test_all_h200_benchmarks_use_saturated_warmups_and_three_runs():
             ), path
 
 
+def test_long_h200_workloads_allow_three_hours():
+    import yaml
+
+    workload_dir = os.path.join(ROOT, "workloads")
+    names = (
+        "deepseek_v4_pro_5_h200.yaml",
+        "gemma_4_31b_it_h200.yaml",
+        "glm_5_1_h200.yaml",
+    )
+    for name in names:
+        path = os.path.join(workload_dir, name)
+        with open(path) as f:
+            workload = yaml.safe_load(f)
+        assert workload.get("timeout_in_minutes") == 180, path
+
+
 def main():
     tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
     failed = 0

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ name: qwen3_5-h200       # used in container name and results/<name>/
 gpu: H200                # picks queue/image/HF cache from lib/gpu_profiles.yaml
 num_gpus: 8
 nightly: true            # include in the nightly schedule (default: false)
+timeout_in_minutes: 180  # Buildkite step timeout (default: 120)
 
 vllm:                    # how the server is brought up
   model: Qwen/Qwen3.5-397B-A17B-FP8
@@ -94,6 +95,7 @@ A few things worth knowing:
 
 - **`gpu`** must match a key in `lib/gpu_profiles.yaml`. The profile sets the Buildkite queue, default image, HF cache path, and baseline env vars.
 - **`nightly`** controls only the nightly schedule. Recipes with `nightly: false` (or omitted) are still triggerable explicitly via the `WORKLOADS` env var.
+- **`timeout_in_minutes`** overrides the Buildkite step timeout (default: `120`). This is separate from `lm_eval.model_args.timeout`, which controls individual API requests.
 - **`lm_eval.tasks` is a list** because each entry runs as a separate `lm_eval` invocation — `--num_fewshot` is a single global flag, so different shot counts need separate runs. Each task's results land in `results/<name>/<task-name>/`.
 - **`vllm_bench` runs first** if both blocks are present — that way perf-pipeline bugs surface quickly instead of waiting on a full lm-eval pass.
 - **`vllm_bench` uses the `random` dataset with `--ignore-eos`** so every request prefills exactly `input_len` and decodes exactly `output_len` tokens — that's what makes the per-GPU decode throughput meaningful. Pair it with `backend: openai` (the `/v1/completions` endpoint) for exact token control. Avoid `dataset: speed_bench` for throughput numbers: it requires `--skip-tokenizer-init`, which makes `vllm bench serve` cap every request at a single output token, so output throughput reads as ~0.

--- a/workloads/deepseek_v4_pro_5_h200.yaml
+++ b/workloads/deepseek_v4_pro_5_h200.yaml
@@ -3,6 +3,7 @@ name: deepseek_v4_pro-h200
 gpu: H200
 num_gpus: 8
 nightly: true
+timeout_in_minutes: 180
 
 vllm:
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/workloads/gemma_4_31b_it_h200.yaml
+++ b/workloads/gemma_4_31b_it_h200.yaml
@@ -3,6 +3,7 @@ name: gemma_4_31b_it_h200
 gpu: H200
 num_gpus: 8
 nightly: true
+timeout_in_minutes: 180
 
 vllm:
   model: RedHatAI/gemma-4-31B-it-FP8-dynamic

--- a/workloads/glm_5_1_h200.yaml
+++ b/workloads/glm_5_1_h200.yaml
@@ -5,6 +5,7 @@ name: glm_5_1-h200
 gpu: H200
 num_gpus: 8
 nightly: true
+timeout_in_minutes: 180
 
 vllm:
   model: zai-org/GLM-5.1-FP8


### PR DESCRIPTION
This PR was authored with assistance from Codex.

## Summary

- raise the Buildkite step timeout from the 120-minute default to 180 minutes for DeepSeek V4 Pro, Gemma 4, and GLM 5.1 H200 workloads
- document that timeout_in_minutes controls the Buildkite step and is separate from the lm-eval request timeout
- add a regression assertion covering the three long-running workloads

## Context

These jobs began hitting the 120-minute cap after H200 serving benchmarks were expanded to three repetitions with saturated warmups. In perf-eval build 428, DeepSeek and GLM were terminated during BFCL multi-turn, while Gemma was terminated during GSM8K after its benchmark repetitions consumed about 100 minutes.

https://buildkite.com/vllm/perf-eval/builds/428

## Testing

- python3 .buildkite/test_generate_pipeline.py (7/7 passed)
- python3 .buildkite/test_benchmark_repetitions.py (7/7 passed)
- generated the three affected workload steps and verified each emits timeout_in_minutes: 180
- git diff --check