### PR TITLE
Add GLM-5.2-FP8 MI355X workload (8k1k perf + gsm8k lm_eval)

### DIFF
--- a/workloads/glm_5_2_mi355x.yaml
+++ b/workloads/glm_5_2_mi355x.yaml
@@ -1,0 +1,40 @@
+# GLM-5.2 (FP8) on AMD MI355X
+name: glm_5_2-mi355x
+gpu: MI355X
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: zai-org/GLM-5.2-FP8
+  env:
+    VLLM_ROCM_USE_AITER: 1
+    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
+    OMP_NUM_THREADS: 1
+  serve_args: >-
+    --tensor-parallel-size 8
+    --trust-remote-code
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      speed_bench_dataset_subset: throughput_8k
+      speed_bench_category: low_entropy


### PR DESCRIPTION
Adds `workloads/glm_5_2_mi355x.yaml` for **GLM-5.2-FP8** on AMD **MI355X**, mirroring `kimi_k2_5_mi355x.yaml`:

- **lm_eval**: gsm8k (5-shot)
- **vllm_bench**: `8k-in-1k-out` (input 8192 / output 1024, 512 prompts, conc 128), `throughput_8k` / `low_entropy`
- `VLLM_ROCM_USE_AITER=1` + the `OMP_NUM_THREADS=1` weight-loading workaround, matching the other MI355X recipes.

Notes: `bfcl` omitted (scope was perf + lm_eval); serve_args kept minimal (tp8 + trust-remote-code) like the other MI355X workloads. Validated locally with `lib/parse_workload.py`.

This PR was authored with assistance from Claude Code (AI-assisted).