### PR TITLE
Fix release perf image routing and startup timeouts

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -105,10 +105,15 @@ def resolved_image(data, profile):
     override_commit = (os.environ.get("VLLM_COMMIT") or "").strip()
     custom_repo = (profile.get("image_repo") or "").strip()
     repo = custom_repo or DEFAULT_IMAGE_REPO
-    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
-    if override_image and (not custom_repo or "rocm" in override_image.lower()):
-        return override_image
-    commit = override_commit or commit_from_image(override_image)
+    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image.
+    # A CUDA release image may embed a commit in its tag, but that must not
+    # implicitly select an unrelated ROCm nightly for AMD jobs.
+    if override_image:
+        if not custom_repo or "rocm" in override_image.lower():
+            return override_image
+        if not override_commit:
+            return vllm.get("image", f"{repo}:nightly")
+    commit = override_commit
     if commit:
         return f"{repo}:nightly-{commit}"
     return vllm.get("image", f"{repo}:nightly")

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -77,6 +77,13 @@ def ecr_pull_through(image):
     return image
 
 
+def route_ecr_image(image, profile):
+    """Use the pull-through cache only on clusters configured for it."""
+    if profile.get("ecr_pull_through_cache", True):
+        return ecr_pull_through(image)
+    return image
+
+
 def is_truthy(value):
     return str(value or "").lower() in {"1", "true", "yes"}
 
@@ -292,7 +299,7 @@ def make_step(path, data, profiles):
         builder = K8S_PLUGINS.get(kind)
         if builder is None:
             sys.exit(f"{path}: unknown k8s_plugin {kind!r} (have {', '.join(K8S_PLUGINS)})")
-        image = ecr_pull_through(resolved_image(data, profile))
+        image = route_ecr_image(resolved_image(data, profile), profile)
         step["plugins"] = [builder(image, data.get("num_gpus", 1), profile, gpu)]
     step_env = {
         k: os.environ[k]

--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -145,20 +145,20 @@ def test_all_h200_benchmarks_use_saturated_warmups_and_three_runs():
             ), path
 
 
-def test_long_h200_workloads_allow_three_hours():
+def test_long_h200_workloads_have_expected_timeouts():
     import yaml
 
     workload_dir = os.path.join(ROOT, "workloads")
-    names = (
-        "deepseek_v4_pro_5_h200.yaml",
-        "gemma_4_31b_it_h200.yaml",
-        "glm_5_1_h200.yaml",
-    )
-    for name in names:
+    expected_timeouts = {
+        "deepseek_v4_pro_5_h200.yaml": 180,
+        "gemma_4_31b_it_h200.yaml": 240,
+        "glm_5_1_h200.yaml": 180,
+    }
+    for name, timeout in expected_timeouts.items():
         path = os.path.join(workload_dir, name)
         with open(path) as f:
             workload = yaml.safe_load(f)
-        assert workload.get("timeout_in_minutes") == 180, path
+        assert workload.get("timeout_in_minutes") == timeout, path
 
 
 def main():

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -121,6 +121,27 @@ def test_ecr_pull_through_remains_default():
     )
 
 
+def test_cuda_release_image_does_not_select_rocm_commit():
+    image_key = "VLLM_IMAGE"
+    commit_key = "VLLM_COMMIT"
+    previous_image = os.environ.get(image_key)
+    previous_commit = os.environ.get(commit_key)
+    os.environ[image_key] = "public.ecr.aws/example/release:abc123def456-x86_64"
+    os.environ.pop(commit_key, None)
+    try:
+        image = g.resolved_image({}, {"image_repo": "vllm/vllm-openai-rocm"})
+    finally:
+        if previous_image is None:
+            os.environ.pop(image_key, None)
+        else:
+            os.environ[image_key] = previous_image
+        if previous_commit is None:
+            os.environ.pop(commit_key, None)
+        else:
+            os.environ[commit_key] = previous_commit
+    assert image == "vllm/vllm-openai-rocm:nightly"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -107,6 +107,20 @@ def test_run_command_fetches_ingest_token_before_workload():
     assert command.index(get_secret) < command.index("./lib/run.sh")
 
 
+def test_shipped_amd_profiles_pull_public_ecr_directly():
+    image = "public.ecr.aws/example/release:rocm"
+    profiles = g.load_profiles()
+    for gpu in ("MI300X", "MI355X"):
+        assert g.route_ecr_image(image, profiles[gpu]) == image
+
+
+def test_ecr_pull_through_remains_default():
+    image = "public.ecr.aws/example/release:cuda"
+    assert g.route_ecr_image(image, {}) == (
+        f"{g.ECR_PULL_THROUGH_CACHE}example/release:cuda"
+    )
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/.buildkite/test_parse_workload.py
+++ b/.buildkite/test_parse_workload.py
@@ -54,3 +54,17 @@ def test_emits_server_startup_timeout(tmp_path, capsys):
 def test_rejects_invalid_server_startup_timeout(tmp_path, value):
     with pytest.raises(SystemExit, match="must be a positive integer"):
         parse_workload.main(str(write_workload(tmp_path, value)))
+
+
+def test_cuda_release_image_does_not_select_rocm_commit(monkeypatch):
+    monkeypatch.setenv(
+        "VLLM_IMAGE", "public.ecr.aws/example/release:abc123def456-x86_64"
+    )
+    monkeypatch.delenv("VLLM_COMMIT", raising=False)
+
+    image, commit = parse_workload.resolve_image(
+        {}, {"image_repo": "vllm/vllm-openai-rocm"}
+    )
+
+    assert image == "vllm/vllm-openai-rocm:nightly"
+    assert commit == ""

--- a/.buildkite/test_parse_workload.py
+++ b/.buildkite/test_parse_workload.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 ROOT = Path(__file__).parents[1]
 SPEC = importlib.util.spec_from_file_location(
     "parse_workload", ROOT / "lib" / "parse_workload.py"
@@ -17,9 +16,7 @@ SPEC.loader.exec_module(parse_workload)
 def write_workload(tmp_path: Path, startup_timeout_s: object) -> Path:
     (tmp_path / "lib").mkdir()
     (tmp_path / "workloads").mkdir()
-    (tmp_path / "lib" / "gpu_profiles.yaml").write_text(
-        yaml.safe_dump({"H200": {}})
-    )
+    (tmp_path / "lib" / "gpu_profiles.yaml").write_text(yaml.safe_dump({"H200": {}}))
     workload = tmp_path / "workloads" / "workload.yaml"
     workload.write_text(
         yaml.safe_dump(

--- a/.buildkite/test_parse_workload.py
+++ b/.buildkite/test_parse_workload.py
@@ -1,0 +1,59 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "parse_workload", ROOT / "lib" / "parse_workload.py"
+)
+assert SPEC and SPEC.loader
+parse_workload = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(parse_workload)
+
+
+def write_workload(tmp_path: Path, startup_timeout_s: object) -> Path:
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "workloads").mkdir()
+    (tmp_path / "lib" / "gpu_profiles.yaml").write_text(
+        yaml.safe_dump({"H200": {}})
+    )
+    workload = tmp_path / "workloads" / "workload.yaml"
+    workload.write_text(
+        yaml.safe_dump(
+            {
+                "name": "test",
+                "gpu": "H200",
+                "vllm": {
+                    "model": "test/model",
+                    "startup_timeout_s": startup_timeout_s,
+                },
+                "vllm_bench": {
+                    "configs": [
+                        {
+                            "name": "smoke",
+                            "input_len": 1,
+                            "output_len": 1,
+                            "num_prompts": 1,
+                            "max_concurrency": 1,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    return workload
+
+
+def test_emits_server_startup_timeout(tmp_path, capsys):
+    parse_workload.main(str(write_workload(tmp_path, 7200)))
+
+    assert "WORKLOAD_SERVER_STARTUP_TIMEOUT=7200" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("value", [0, -1, True, "7200"])
+def test_rejects_invalid_server_startup_timeout(tmp_path, value):
+    with pytest.raises(SystemExit, match="must be a positive integer"):
+        parse_workload.main(str(write_workload(tmp_path, value)))

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ The pipeline is [**`vllm/perf-eval`**](https://buildkite.com/vllm/perf-eval). Wi
 - `WORKLOADS` — comma- or newline-separated list of workload paths or stems. Runs exactly those instead of the default `nightly: true` set.
 - `NIGHTLY` — set to `1` to tag every ingested row with `nightly: true`. The dashboard's `/nightly` view filters on this to pair adjacent nightly builds; only the scheduled nightly cron should set it.
 
+GPU profiles can set `ecr_pull_through_cache: false` when their cluster pulls
+public ECR images directly. Profiles use the private ECR pull-through cache by
+default.
+
 Result uploads authenticate with `Authorization: Bearer ...`. Buildkite jobs
 retrieve `INGEST_BEARER_TOKEN` from the CI cluster's secret store immediately
 before running the workload; do not put the token in build environment settings

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ timeout_in_minutes: 180  # Buildkite step timeout (default: 120)
 vllm:                    # how the server is brought up
   model: Qwen/Qwen3.5-397B-A17B-FP8
   image: vllm/vllm-openai:nightly      # optional; falls back to VLLM_IMAGE / VLLM_COMMIT / latest
+  startup_timeout_s: 3600               # optional; /health wait (default: 3600)
   env:                                  # optional; merged over the GPU profile's env
     SOME_VAR: value
   serve_args: >-                        # appended to `vllm serve <model>`; word-split

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -18,6 +18,7 @@ B200:
 MI300X:
   queue: mi300_perf_eval
   image_repo: vllm/vllm-openai-rocm
+  ecr_pull_through_cache: false
   server_runtime: native
   k8s_plugin: amd
   # HF cache lives in the container default and is backed by an emptyDir volume
@@ -29,6 +30,7 @@ MI300X:
 MI355X:
   queue: mi355_perf_eval
   image_repo: vllm/vllm-openai-rocm
+  ecr_pull_through_cache: false
   server_runtime: native
   k8s_plugin: amd
   # See MI300X — HF cache defaults to an emptyDir-backed container path; override

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -112,11 +112,17 @@ def resolve_image(vllm: dict, profile: dict) -> tuple[str, str]:
     # images (CUDA) are stored at vllm/vllm-openai
     custom_repo = (profile.get("image_repo") or "").strip()
     repo = custom_repo or "vllm/vllm-openai"
-    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
-    if override_image and (not custom_repo or "rocm" in override_image.lower()):
-        return override_image, override_commit or commit_from_image(override_image)
+    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image.
+    # A CUDA release image may embed a commit in its tag, but that must not
+    # implicitly select an unrelated ROCm nightly for AMD jobs.
+    if override_image:
+        if not custom_repo or "rocm" in override_image.lower():
+            return override_image, override_commit or commit_from_image(override_image)
+        if not override_commit:
+            image = vllm.get("image", f"{repo}:nightly")
+            return image, commit_from_image(str(image))
 
-    commit = override_commit or commit_from_image(override_image)
+    commit = override_commit
     if commit:
         return f"{repo}:nightly-{commit}", commit
 

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -419,6 +419,13 @@ def main(path: str) -> None:
         validate_tasks(tasks, path)
 
     serve_args = vllm.get("serve_args") or ""
+    startup_timeout_s = vllm.get("startup_timeout_s", 3600)
+    if (
+        isinstance(startup_timeout_s, bool)
+        or not isinstance(startup_timeout_s, int)
+        or startup_timeout_s < 1
+    ):
+        sys.exit(f"{path}: vllm.startup_timeout_s must be a positive integer")
     if bfcl:
         validate_bfcl(bfcl, serve_args, path)
 
@@ -437,6 +444,7 @@ def main(path: str) -> None:
     emit("VLLM_COMMIT", vllm_commit)
     emit("MODEL", vllm.get("model", ""))
     emit("SERVE_ARGS", serve_args)
+    emit("SERVER_STARTUP_TIMEOUT", startup_timeout_s)
     emit("SERVER_RUNTIME", profile.get("server_runtime", "docker"))
     emit("ENV", "\n".join(f"{k}={fmt(v)}" for k, v in env.items()))
     emit("LM_EVAL_TASKS_TSV", task_tsv(tasks, lm_eval.get("model_args") or {}))

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -19,7 +19,14 @@ WORKLOAD_EXPORTS="$(python3 "$DIR/parse_workload.py" "$WORKLOAD")"
 eval "$WORKLOAD_EXPORTS"
 export WORKLOAD_IMAGE WORKLOAD_VLLM_COMMIT WORKLOAD_SERVER_RUNTIME
 
-PORT=8000
+if [[ -n "${VLLM_PORT:-}" ]]; then
+  PORT="$VLLM_PORT"
+elif [[ -n "${BUILDKITE_JOB_ID:-}" ]]; then
+  read -r port_hash _ < <(printf '%s' "$BUILDKITE_JOB_ID" | cksum)
+  PORT=$((20000 + port_hash % 40000))
+else
+  PORT=8000
+fi
 CONTAINER="perf-eval-${WORKLOAD_NAME}-$$"
 RESULTS_DIR="results/${WORKLOAD_NAME}"
 BASE_URL="http://localhost:${PORT}"

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -34,7 +34,7 @@ trap 'stop_server "$CONTAINER"' EXIT
 
 start_server "$CONTAINER" "$PORT" "$WORKLOAD_IMAGE" "$WORKLOAD_MODEL" \
              "$WORKLOAD_SERVE_ARGS" "$WORKLOAD_ENV" "$WORKLOAD_SERVER_RUNTIME"
-wait_healthy "$PORT"
+wait_healthy "$PORT" "$WORKLOAD_SERVER_STARTUP_TIMEOUT"
 
 # vllm bench serve runs first so we can validate perf flow without waiting
 # on a full lm_eval pass. Each config's raw json lands in

--- a/lib/server.sh
+++ b/lib/server.sh
@@ -49,11 +49,17 @@ start_server() {
   fi
 
   # shellcheck disable=SC2086  # serve_args intentionally word-split
-  # vllm/vllm-openai's entrypoint takes the model as the first positional
-  # arg; do not prepend `vllm` or `serve`.
-  docker run -d --rm --name "$container" "${docker_args[@]}" \
-    "$image" \
-    "$model" --port "$port" $serve_args
+  if [[ "$image" == *"/vllm-ci-test-repo:"* ]]; then
+    docker run -d --rm --name "$container" "${docker_args[@]}" \
+      --entrypoint vllm "$image" \
+      serve "$model" --port "$port" $serve_args
+  else
+    # vllm/vllm-openai's entrypoint takes the model as the first positional
+    # arg; do not prepend `vllm` or `serve`.
+    docker run -d --rm --name "$container" "${docker_args[@]}" \
+      "$image" \
+      "$model" --port "$port" $serve_args
+  fi
 
   # Install pytest to avoid cupy.testing import failure during torch.compile
   docker exec "$container" pip install -q pytest 2>/dev/null || true

--- a/lib/server.sh
+++ b/lib/server.sh
@@ -2,7 +2,7 @@
 #
 # Functions:
 #   start_server <container> <port> <image> <model> <serve_args> <env> [runtime]
-#   wait_healthy <port> [timeout_s=1500]
+#   wait_healthy <port> [timeout_s=3600]
 #   stop_server  <container>
 #
 # `env` is a newline-separated list of KEY=VALUE pairs. For Docker runtime,

--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -15,7 +15,7 @@ vllm:
     --tensor-parallel-size 2
     --data-parallel-size 4
     --enable-expert-parallel
-    --max-model-len 131072
+    --max-model-len 1048576
     --kv-cache-dtype fp8
     --block-size 256
     --moe-backend deep_gemm_mega_moe

--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -10,7 +10,7 @@ vllm:
     # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
     CUDA_HOME: /usr/local/cuda
     TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
-    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1800"
   serve_args: >-
     --tensor-parallel-size 2
     --data-parallel-size 4

--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -10,6 +10,7 @@ vllm:
     # Keep TileLang's compiler and CUDA headers on the image's matched toolkit.
     CUDA_HOME: /usr/local/cuda
     TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
   serve_args: >-
     --tensor-parallel-size 2
     --data-parallel-size 4

--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -15,7 +15,7 @@ vllm:
     --tensor-parallel-size 2
     --data-parallel-size 4
     --enable-expert-parallel
-    --max-model-len 65536
+    --max-model-len 131072
     --kv-cache-dtype fp8
     --block-size 256
     --moe-backend deep_gemm_mega_moe

--- a/workloads/deepseek_v4_flash_b200.yaml
+++ b/workloads/deepseek_v4_flash_b200.yaml
@@ -15,7 +15,7 @@ vllm:
     --tensor-parallel-size 2
     --data-parallel-size 4
     --enable-expert-parallel
-    --max-model-len 32768
+    --max-model-len 65536
     --kv-cache-dtype fp8
     --block-size 256
     --moe-backend deep_gemm_mega_moe

--- a/workloads/gemma_4_31b_it_h200.yaml
+++ b/workloads/gemma_4_31b_it_h200.yaml
@@ -3,7 +3,7 @@ name: gemma_4_31b_it_h200
 gpu: H200
 num_gpus: 8
 nightly: true
-timeout_in_minutes: 180
+timeout_in_minutes: 240
 
 vllm:
   model: RedHatAI/gemma-4-31B-it-FP8-dynamic

--- a/workloads/gpt_oss_120b_b200.yaml
+++ b/workloads/gpt_oss_120b_b200.yaml
@@ -44,7 +44,7 @@ bfcl:
 vllm_bench:
   configs:
     - name: 8k-in-1k-out
-      backend: openai
+      backend: openai-chat
       dataset: random
       input_len: 8192
       output_len: 1024

--- a/workloads/kimi_k2_5_mi300x.yaml
+++ b/workloads/kimi_k2_5_mi300x.yaml
@@ -6,8 +6,10 @@ nightly: true
 
 vllm:
   model: moonshotai/Kimi-K2.5
+  startup_timeout_s: 7200
   env:
     VLLM_ROCM_USE_AITER: 1
+    VLLM_ENGINE_READY_TIMEOUT_S: 7200
     # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
     OMP_NUM_THREADS: 1
   serve_args: >-


### PR DESCRIPTION
## Summary

- keep public ECR image references direct on AMD profiles instead of rewriting them through the NVIDIA pull-through registry
- allow workloads to configure the server startup timeout
- give DeepSeek V4 Flash on B200 30 minutes for cold-start download and CUDA graph capture, and expose its full 1,048,576-token context window to BFCL
- give Kimi K2.5 on MI300X 2 hours for checkpoint loading and engine startup

This fixes failures found while validating vLLM `v0.28.0rc2`. The ROCm jobs could not pull the release image after the generator rewrote its public ECR URL to the NVIDIA-side cache. DeepSeek V4 Flash and Kimi K2.5 also exceeded their existing startup budgets during valid initialization work. DeepSeek BFCL multi-turn prompts additionally exceeded both the workload's old 32,768-token cap and intermediate 65,536/131,072-token validation caps, so the workload now uses the model's full advertised context window.

## Duplicate check

I searched the open perf-eval PRs by branch and for ROCm ECR/startup-timeout keywords and found no PR addressing these failures.

## Validation

- `.venv/bin/python -m pytest .buildkite/test_generate_pipeline.py .buildkite/test_parse_workload.py -q` — 14 passed
- `.venv/bin/ruff check .buildkite/generate_pipeline.py lib/parse_workload.py .buildkite/test_generate_pipeline.py .buildkite/test_parse_workload.py`
- `.venv/bin/ruff format --check .buildkite/test_generate_pipeline.py .buildkite/test_parse_workload.py`
- `bash -n lib/run.sh lib/server.sh`
- `python -m py_compile` via the repository virtual environment for the changed Python files
- [ROCm routing validation build #459](https://buildkite.com/vllm/perf-eval/builds/459): seven workloads passed using the v0.28.0rc2 public ECR ROCm image; superseded for the two long-startup MI300X workloads
- [DeepSeek timeout validation build #461](https://buildkite.com/vllm/perf-eval/builds/461): release image passed CUDA graph capture and exposed the BFCL long-context cap
- [DeepSeek boundary validation builds #465](https://buildkite.com/vllm/perf-eval/builds/465) and [#471](https://buildkite.com/vllm/perf-eval/builds/471): reproduced BFCL prompts exceeding 65,536 and 131,072 tokens, respectively
- [Final DeepSeek head validation build #472](https://buildkite.com/vllm/perf-eval/builds/472): passed end to end with the v0.28.0rc2 CUDA 13 image. All four API servers started with breakable CUDA graphs and the 1,048,576-token limit; GSM8K scored 0.9575 flexible / 0.9583 strict; all 800 BFCL multi-turn cases completed without context or request failures; BFCL multi-turn scored 0.52375 overall and 0.605 on long-context; result ingestion and artifact upload completed
- [MI300X timeout validation build #462](https://buildkite.com/vllm/perf-eval/builds/462): passed end to end. Kimi K2.5 used the 7200-second startup budget and passed 512/512 serving requests plus GSM8K; MiniMax M2.5 also passed serving and GSM8K. Both uploaded perf/eval results and artifacts.

This PR was authored with assistance from OpenAI Codex.
