### PR TITLE
Update workloads: GLM-5.3, Kimi K3, MiniMax M3; add pin_image

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -98,12 +98,16 @@ def resolved_image(data, profile):
     override_commit = (os.environ.get("VLLM_COMMIT") or "").strip()
     custom_repo = (profile.get("image_repo") or "").strip()
     repo = custom_repo or DEFAULT_IMAGE_REPO
-    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
-    if override_image and (not custom_repo or "rocm" in override_image.lower()):
-        return override_image
-    commit = override_commit or commit_from_image(override_image)
-    if commit:
-        return f"{repo}:nightly-{commit}"
+    # A workload that sets pin_image: true keeps its own vllm.image even when
+    # VLLM_IMAGE / VLLM_COMMIT are set (the model only exists in that image).
+    pinned = vllm.get("pin_image") is True and vllm.get("image")
+    if not pinned:
+        # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
+        if override_image and (not custom_repo or "rocm" in override_image.lower()):
+            return override_image
+        commit = override_commit or commit_from_image(override_image)
+        if commit:
+            return f"{repo}:nightly-{commit}"
     return vllm.get("image", f"{repo}:nightly")
 
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ timeout_in_minutes: 180  # Buildkite step timeout (default: 120)
 vllm:                    # how the server is brought up
   model: Qwen/Qwen3.5-397B-A17B-FP8
   image: vllm/vllm-openai:nightly      # optional; falls back to VLLM_IMAGE / VLLM_COMMIT / latest
+  pin_image: true                       # optional; keep `image` even when VLLM_IMAGE / VLLM_COMMIT are set
   env:                                  # optional; merged over the GPU profile's env
     SOME_VAR: value
   serve_args: >-                        # appended to `vllm serve <model>`; word-split
@@ -94,6 +95,7 @@ vllm_bench:              # perf runs (optional) — fed to the perf dashboard
 A few things worth knowing:
 
 - **`gpu`** must match a key in `lib/gpu_profiles.yaml`. The profile sets the Buildkite queue, default image, HF cache path, and baseline env vars.
+- **`vllm.image` is normally just a fallback.** The `VLLM_IMAGE` / `VLLM_COMMIT` build-time env vars override it, which is what you want for nightly perf tracking across a specific vLLM commit. Set **`pin_image: true`** to make a workload keep its own `image` regardless — required for models that only exist in a dedicated image (e.g. `kimi-k3`, `minimax-m3`), where the nightly override would pull an image that cannot serve the model.
 - **`nightly`** controls only the nightly schedule. Recipes with `nightly: false` (or omitted) are still triggerable explicitly via the `WORKLOADS` env var.
 - **`timeout_in_minutes`** overrides the Buildkite step timeout (default: `120`). This is separate from `lm_eval.model_args.timeout`, which controls individual API requests.
 - **`lm_eval.tasks` is a list** because each entry runs as a separate `lm_eval` invocation — `--num_fewshot` is a single global flag, so different shot counts need separate runs. Each task's results land in `results/<name>/<task-name>/`.

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -105,20 +105,29 @@ def load_profile(gpu: str, workload_path: str) -> dict:
 
 
 def resolve_image(vllm: dict, profile: dict) -> tuple[str, str]:
-    """Pick the image and commit using VLLM_IMAGE / VLLM_COMMIT / workload."""
+    """Pick the image and commit using VLLM_IMAGE / VLLM_COMMIT / workload.
+
+    A workload that sets ``pin_image: true`` keeps its own ``vllm.image`` even
+    when VLLM_IMAGE / VLLM_COMMIT are set. Use it for models that only exist in
+    a dedicated image (e.g. kimi-k3, minimax-m3) where the nightly override
+    would pull an image that cannot serve the model.
+    """
     override_image = (os.environ.get("VLLM_IMAGE") or "").strip()
     override_commit = (os.environ.get("VLLM_COMMIT") or "").strip()
     # ROCm images are located at vllm/vllm-openai-rocm. The default
     # images (CUDA) are stored at vllm/vllm-openai
     custom_repo = (profile.get("image_repo") or "").strip()
     repo = custom_repo or "vllm/vllm-openai"
-    # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
-    if override_image and (not custom_repo or "rocm" in override_image.lower()):
-        return override_image, override_commit or commit_from_image(override_image)
 
-    commit = override_commit or commit_from_image(override_image)
-    if commit:
-        return f"{repo}:nightly-{commit}", commit
+    pinned = vllm.get("pin_image") is True and vllm.get("image")
+    if not pinned:
+        # Don't use VLLM_IMAGE for AMD workloads unless it is a ROCm image
+        if override_image and (not custom_repo or "rocm" in override_image.lower()):
+            return override_image, override_commit or commit_from_image(override_image)
+
+        commit = override_commit or commit_from_image(override_image)
+        if commit:
+            return f"{repo}:nightly-{commit}", commit
 
     image = vllm.get("image", f"{repo}:nightly")
     return image, commit_from_image(str(image))

--- a/workloads/glm_5_3_h200.yaml
+++ b/workloads/glm_5_3_h200.yaml
@@ -18,7 +18,6 @@ vllm:
     --tool-call-parser glm47
     --reasoning-parser glm45
     --enable-auto-tool-choice
-    --served-model-name glm-5.3
 
 lm_eval:
   model_args:
@@ -47,7 +46,7 @@ vllm_bench:
     # The native-FP8 checkpoint has no precision marker in its repo name.
     precision: fp8
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/glm_5_3_h200.yaml
+++ b/workloads/glm_5_3_h200.yaml
@@ -1,0 +1,56 @@
+# GLM-5.3 (native FP8) on H200
+# Recipe: https://recipes.vllm.ai/zai-org/GLM-5.3 (requires vLLM 0.28.0+)
+# The default zai-org/GLM-5.3 checkpoint is native FP8 (BF16 lives in
+# zai-org/GLM-5.3-BF16). MTP speculative decoding is part of the recommended
+# config; the recipe bumped num_speculative_tokens from 3 (GLM-5.1) to 5.
+name: glm_5_3-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: zai-org/GLM-5.3
+  serve_args: >-
+    --tensor-parallel-size 8
+    --kv-cache-dtype fp8
+    --speculative-config.method mtp
+    --speculative-config.num_speculative_tokens 5
+    --tool-call-parser glm47
+    --reasoning-parser glm45
+    --enable-auto-tool-choice
+    --served-model-name glm-5.3
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  metadata:
+    # The native-FP8 checkpoint has no precision marker in its repo name.
+    precision: fp8
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128

--- a/workloads/glm_5_3_h200.yaml
+++ b/workloads/glm_5_3_h200.yaml
@@ -53,3 +53,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/kimi_k3_mi355x.yaml
+++ b/workloads/kimi_k3_mi355x.yaml
@@ -3,8 +3,9 @@
 # K3 needs at least 8x MI355X/MI350X on ROCm (8x GB300 on NVIDIA) — there is
 # no H200 profile, the 2.8T model does not fit on Hopper. Requires the
 # dedicated kimi-k3 image; support is not in a stable release yet.
-# AITER_SITUV2_A8W4=0 selects the aiter a16w4 MoE path on gfx950 (set to 1
-# for the a8w4 path).
+# Env matches the verified MI355X profile: VLLM_USE_BREAKABLE_CUDAGRAPH=0 is
+# required, and VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1 selects the aiter a8w4
+# MoE path on gfx950 (CDNA4).
 name: kimi_k3-mi355x
 gpu: MI355X
 num_gpus: 8
@@ -19,7 +20,8 @@ vllm:
   pin_image: true
   env:
     VLLM_ROCM_USE_AITER: 1
-    AITER_SITUV2_A8W4: 0
+    VLLM_USE_BREAKABLE_CUDAGRAPH: 0
+    VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code
@@ -38,13 +40,14 @@ lm_eval:
         max_gen_toks: 32768
 
 vllm_bench:
+  metadata:
+    # The default K3 checkpoint is MXFP4; the repo name has no precision marker.
+    precision: mxfp4
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
-      speed_bench_dataset_subset: throughput_8k
-      speed_bench_category: low_entropy

--- a/workloads/kimi_k3_mi355x.yaml
+++ b/workloads/kimi_k3_mi355x.yaml
@@ -1,0 +1,50 @@
+# Kimi-K3 on AMD MI355X
+# Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K3
+# K3 needs at least 8x MI355X/MI350X on ROCm (8x GB300 on NVIDIA) — there is
+# no H200 profile, the 2.8T model does not fit on Hopper. Requires the
+# dedicated kimi-k3 image; support is not in a stable release yet.
+# AITER_SITUV2_A8W4=0 selects the aiter a16w4 MoE path on gfx950 (set to 1
+# for the a8w4 path).
+name: kimi_k3-mi355x
+gpu: MI355X
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: moonshotai/Kimi-K3
+  # K3 support is only in this dedicated image, not in any stable/nightly
+  # build — pin it so the VLLM_IMAGE / VLLM_COMMIT trigger override cannot
+  # swap in a nightly that cannot serve the model.
+  image: vllm/vllm-openai_rocm:kimi-k3
+  pin_image: true
+  env:
+    VLLM_ROCM_USE_AITER: 1
+    AITER_SITUV2_A8W4: 0
+  serve_args: >-
+    --tensor-parallel-size 8
+    --trust-remote-code
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128
+      speed_bench_dataset_subset: throughput_8k
+      speed_bench_category: low_entropy

--- a/workloads/minimax_m3_b200.yaml
+++ b/workloads/minimax_m3_b200.yaml
@@ -10,7 +10,11 @@ nightly: true
 
 vllm:
   model: nvidia/MiniMax-M3-NVFP4
+  # M3 support is only in this dedicated image, not in any stable/nightly
+  # build — pin it so the VLLM_IMAGE / VLLM_COMMIT trigger override cannot
+  # swap in a nightly that cannot serve the model.
   image: vllm/vllm-openai:minimax-m3
+  pin_image: true
   env:
     VLLM_FLOAT32_MATMUL_PRECISION: high
   serve_args: >-

--- a/workloads/minimax_m3_h200.yaml
+++ b/workloads/minimax_m3_h200.yaml
@@ -46,7 +46,7 @@ bfcl:
 
 vllm_bench:
   configs:
-    - name: 8k-in-1k-out-conc-128
+    - name: 8k-in-1k-out
       backend: openai
       dataset: random
       input_len: 8192

--- a/workloads/minimax_m3_h200.yaml
+++ b/workloads/minimax_m3_h200.yaml
@@ -1,0 +1,55 @@
+# MiniMax-M3 (BF16) on H200
+# Recipe: https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3
+# NVIDIA baseline is single-node TP=8 on 8x H200/H20. --block-size 128 is
+# mandatory on every platform (MSA sparse/index cache). Support has not
+# shipped in a stable vLLM release yet — use the dedicated image.
+name: minimax_m3-h200
+gpu: H200
+num_gpus: 8
+nightly: true
+
+vllm:
+  model: MiniMaxAI/MiniMax-M3
+  # M3 support is only in this dedicated image, not in any stable/nightly
+  # build — pin it so the VLLM_IMAGE / VLLM_COMMIT trigger override cannot
+  # swap in a nightly that cannot serve the model.
+  image: vllm/vllm-openai:minimax-m3
+  pin_image: true
+  serve_args: >-
+    --tensor-parallel-size 8
+    --block-size 128
+    --tool-call-parser minimax_m3
+    --reasoning-parser minimax_m3
+    --enable-auto-tool-choice
+
+lm_eval:
+  model_args:
+    tokenized_requests: false
+    tokenizer_backend: null
+    timeout: 6000
+  tasks:
+    - name: gsm8k
+      num_fewshot: 5
+      model_args:
+        num_concurrent: 64
+        max_length: 40960
+        max_gen_toks: 32768
+
+bfcl:
+  test_categories:
+    - simple_python
+    - multiple
+    - parallel
+    - parallel_multiple
+    - multi_turn
+  num_threads: 8
+
+vllm_bench:
+  configs:
+    - name: 8k-in-1k-out-conc-128
+      backend: openai
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 512
+      max_concurrency: 128

--- a/workloads/minimax_m3_h200.yaml
+++ b/workloads/minimax_m3_h200.yaml
@@ -53,3 +53,6 @@ vllm_bench:
       output_len: 1024
       num_prompts: 512
       max_concurrency: 128
+      repetitions: 3
+      args:
+        num_warmups: 128

--- a/workloads/minimax_m3_h200.yaml
+++ b/workloads/minimax_m3_h200.yaml
@@ -3,6 +3,10 @@
 # NVIDIA baseline is single-node TP=8 on 8x H200/H20. --block-size 128 is
 # mandatory on every platform (MSA sparse/index cache). Support has not
 # shipped in a stable vLLM release yet — use the dedicated image.
+# BF16 weights (~795 GiB) leave only ~5 GiB of KV cache per 8xH200 node, far
+# short of the ~44 GiB the native 1M context needs. --max-model-len 65536 caps
+# the window so the engine fits (covers the 40960 lm_eval length and the 8k/1k
+# bench with headroom); the full 1M window needs multi-node TP per the recipe.
 name: minimax_m3-h200
 gpu: H200
 num_gpus: 8
@@ -18,6 +22,7 @@ vllm:
   serve_args: >-
     --tensor-parallel-size 8
     --block-size 128
+    --max-model-len 65536
     --tool-call-parser minimax_m3
     --reasoning-parser minimax_m3
     --enable-auto-tool-choice


### PR DESCRIPTION
This PR was authored with assistance from Kimi Code CLI.

## Summary

Refresh the workload set for the upcoming release while keeping the legacy
models alongside for comparison (deprecation to follow in a later PR):

- **GLM-5.3 on H200** (`workloads/glm_5_3_h200.yaml`) alongside GLM-5.1. Per
  the [recipe](https://recipes.vllm.ai/zai-org/GLM-5.3): the default
  `zai-org/GLM-5.3` checkpoint is now native FP8, adds `--kv-cache-dtype fp8`,
  and MTP `num_speculative_tokens` goes 3 → 5. Requires vLLM ≥ 0.28.0.
- **Kimi K3 on MI355X** (`workloads/kimi_k3_mi355x.yaml`) alongside K2.5. Per
  the [recipe](https://recipes.vllm.ai/moonshotai/Kimi-K3), K3 needs at least
  8x GB300 (NVIDIA) or 8x MI355X (ROCm) — there is no H200 profile, so K3 does
  not replace the K2.5 H200 lane. Uses the dedicated
  `vllm/vllm-openai_rocm:kimi-k3` image and `AITER_SITUV2_A8W4=0` (aiter a16w4
  MoE path on gfx950).
- **MiniMax M3 on H200** (`workloads/minimax_m3_h200.yaml`) alongside M2.5. Per
  the [recipe](https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3): BF16 TP8 on
  8xH200, mandatory `--block-size 128` (MSA), `minimax_m3` parsers, dedicated
  `vllm/vllm-openai:minimax-m3` image.

No existing workloads are removed — GLM-5.1, Kimi K2.5, MiniMax M2.5, and
GPT-OSS-120B all stay so old and new numbers can be compared for the release.

## `pin_image`

`vllm.image` is normally just a fallback — the `VLLM_IMAGE` / `VLLM_COMMIT`
build-time env vars override it (what you want for nightly perf tracking). But
K3 and M3 only ship in dedicated images (`kimi-k3`, `minimax-m3`); the nightly
override would pull an image that cannot serve the model and fail at startup.

`vllm.pin_image: true` makes a workload keep its own `image` regardless of the
trigger-time override. The parser (`lib/parse_workload.py`) and the pipeline
generator (`.buildkite/generate_pipeline.py`) honor it identically so the step
label and the runtime image agree. Backward compatible: workloads that do not
opt in (e.g. the existing `minimax_m3_b200`) are unchanged. Documented in the
README.

## Validation

- Real lm-eval 0.4.13 registry parse: all workloads pass.
- `python3 .buildkite/test_generate_pipeline.py` — 7/7.
- `bash -n lib/run.sh lib/server.sh lib/run_lm_eval.sh lib/run_vllm_bench.sh`.
- `python3 -m py_compile lib/parse_workload.py lib/ingest_perf.py .buildkite/generate_pipeline.py`.
- pin_image behavior verified: with `VLLM_IMAGE`/`VLLM_COMMIT` set, pinned
  workloads keep their dedicated image while unpinned ones take the override.

## Notes

- K3 and MiniMax M3 support are not in a stable vLLM release; both rely on
  their dedicated images (hence `pin_image`).
- A separate stacked PR (#71) adds Kimi K3 GB300 Slurm PD workloads (regular
  and DSpark) on top of #36.