### PR TITLE
Remove image pins from MiniMax M3 and Kimi K3 workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ vllm_bench:              # perf runs (optional) — fed to the perf dashboard
 A few things worth knowing:
 
 - **`gpu`** must match a key in `lib/gpu_profiles.yaml`. The profile sets the Buildkite queue, default image, HF cache path, and baseline env vars.
-- **`vllm.image` is normally just a fallback.** The `VLLM_IMAGE` / `VLLM_COMMIT` build-time env vars override it, which is what you want for nightly perf tracking across a specific vLLM commit. Set **`pin_image: true`** to make a workload keep its own `image` regardless — required for models that only exist in a dedicated image (e.g. `kimi-k3`, `minimax-m3`), where the nightly override would pull an image that cannot serve the model.
+- **`vllm.image` is normally just a fallback.** The `VLLM_IMAGE` / `VLLM_COMMIT` build-time env vars override it, which is what you want for nightly perf tracking across a specific vLLM commit. Set **`pin_image: true`** only as a rare escape hatch for a model that genuinely cannot be served by the nightly under test (e.g. support landed in a dedicated image but not yet in nightly) — it makes the workload keep its own `image` regardless of the override. Do not pin models that current nightlies already serve.
 - **`nightly`** controls only the nightly schedule. Recipes with `nightly: false` (or omitted) are still triggerable explicitly via the `WORKLOADS` env var.
 - **`timeout_in_minutes`** overrides the Buildkite step timeout (default: `120`). This is separate from `lm_eval.model_args.timeout`, which controls individual API requests.
 - **`lm_eval.tasks` is a list** because each entry runs as a separate `lm_eval` invocation — `--num_fewshot` is a single global flag, so different shot counts need separate runs. Each task's results land in `results/<name>/<task-name>/`.

--- a/workloads/kimi_k3_mi355x.yaml
+++ b/workloads/kimi_k3_mi355x.yaml
@@ -13,11 +13,8 @@ nightly: true
 
 vllm:
   model: moonshotai/Kimi-K3
-  # K3 support is only in this dedicated image, not in any stable/nightly
-  # build — pin it so the VLLM_IMAGE / VLLM_COMMIT trigger override cannot
-  # swap in a nightly that cannot serve the model.
-  image: vllm/vllm-openai_rocm:kimi-k3
-  pin_image: true
+  # No image: like the other workloads, default to the nightly under test
+  # (K3 support is in current nightlies).
   env:
     VLLM_ROCM_USE_AITER: 1
     VLLM_USE_BREAKABLE_CUDAGRAPH: 0

--- a/workloads/minimax_m3_b200.yaml
+++ b/workloads/minimax_m3_b200.yaml
@@ -10,11 +10,8 @@ nightly: true
 
 vllm:
   model: nvidia/MiniMax-M3-NVFP4
-  # M3 support is only in this dedicated image, not in any stable/nightly
-  # build — pin it so the VLLM_IMAGE / VLLM_COMMIT trigger override cannot
-  # swap in a nightly that cannot serve the model.
-  image: vllm/vllm-openai:minimax-m3
-  pin_image: true
+  # No image: like the other workloads, default to the nightly under test
+  # (M3 NVFP4 support is in current nightlies, vllm-project/vllm#46380).
   env:
     VLLM_FLOAT32_MATMUL_PRECISION: high
   serve_args: >-

--- a/workloads/minimax_m3_h200.yaml
+++ b/workloads/minimax_m3_h200.yaml
@@ -14,11 +14,8 @@ nightly: true
 
 vllm:
   model: MiniMaxAI/MiniMax-M3
-  # M3 support is only in this dedicated image, not in any stable/nightly
-  # build — pin it so the VLLM_IMAGE / VLLM_COMMIT trigger override cannot
-  # swap in a nightly that cannot serve the model.
-  image: vllm/vllm-openai:minimax-m3
-  pin_image: true
+  # No image: like the other workloads, default to the nightly under test
+  # (M3 support is in current nightlies).
   serve_args: >-
     --tensor-parallel-size 8
     --block-size 128


### PR DESCRIPTION
This PR was authored with assistance from Kimi Code CLI.

## Summary

Removes the dedicated `vllm.image` (and the briefly-added `pin_image: true`)
from the MiniMax M3 and Kimi K3 workloads added in #70, so they default to the
nightly under test like every other workload in the repo.

The premise for pinning — that these models only run in their dedicated images
— no longer holds:

- **MiniMax-M3 NVFP4** support merged into vLLM in June
  ([vllm-project/vllm#46380](https://github.com/vllm-project/vllm/pull/46380)).
- **Kimi K3** is registered in vLLM main (`KimiK3ForConditionalGeneration`,
  including the `dspark_mla` draft head).

These three were the only workloads in the repo setting a dedicated `image:`
(21 others omit it and default to nightly). perf-eval exists to test nightlies,
so a hardcoded image works against that.

## What changed

- `minimax_m3_b200`, `minimax_m3_h200`, `kimi_k3_mi355x`: dropped `image:` and
  `pin_image:`. They now resolve to `vllm/vllm-openai:nightly[-<commit>]` (or
  `vllm/vllm-openai-rocm:nightly[-<commit>]` for the MI355X profile), and the
  `VLLM_IMAGE` / `VLLM_COMMIT` override applies as it does for all other
  workloads.
- README: kept the `pin_image` mechanism documented as a rare escape hatch, but
  no longer cites kimi-k3 / minimax-m3 as models that need it.

The `pin_image` resolver mechanism (parser + generator) is unchanged and remains
available for a future model that lands in a dedicated image before nightly.

## Validation

- Resolver verified: with no override the three now default to
  `vllm/vllm-openai:nightly` (M3) / `vllm/vllm-openai-rocm:nightly` (K3 MI355X);
  with `VLLM_COMMIT` set they resolve to `nightly-<commit>`.
- `python3 .buildkite/test_generate_pipeline.py` — 7/7.
- `python3 .buildkite/test_benchmark_repetitions.py` — 7/7.
- `bash -n lib/run.sh lib/server.sh`; `py_compile` parser + generator;
  `git diff --check`.
