### PR TITLE
Add GB300 Slurm PD serving infrastructure and Kimi K3 PD workloads

### DIFF
--- a/.agents/skills/vllm-pd-disagg-model-onboarding/SKILL.md
+++ b/.agents/skills/vllm-pd-disagg-model-onboarding/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: vllm-pd-disagg-model-onboarding
+description: Add, adapt, debug, and validate a model-specific vLLM prefill/decode-disaggregated serving workload in perf-eval, especially multi-node Slurm/Pyxis deployments using NIXL and vllm-router. Use this whenever a user asks to onboard another model to PD disaggregation, change prefill/decode topology (DEP, TEP, TP, DP, or EP), port an internal serving recipe into perf-eval, or diagnose a PD-disaggregated Buildkite/Slurm bring-up. Do not use for ordinary single-server workloads that omit the serving block.
+compatibility: Requires the perf-eval repository. Real bring-up requires SSH access to a Slurm login node with Pyxis, shared storage, the model checkpoint, and a compatible vllm-router build; Buildkite testing requires an online queue agent.
+---
+
+# vLLM PD-disaggregated model onboarding
+
+Turn a model serving recipe into a reviewable, reproducible perf-eval workload, prove it on the Slurm cluster, and only then exercise the Buildkite path.
+
+Read [references/model-onboarding.md](references/model-onboarding.md) before editing. It contains the field-by-field checklist, topology formulas, staged validation commands, and failure guide distilled from the first Kimi GB300 deployment.
+
+## 1. Establish scope and preserve the worktree
+
+1. Read `AGENTS.md`, `CLAUDE.md`, and the PD section of `README.md`.
+2. Inspect `git status`, the current branch, and active worktrees. Preserve unrelated and untracked changes. Prefer a dedicated branch or existing task worktree.
+3. Treat these files as the current implementation contract:
+   - `workloads/kimi_k3_gb300_pd.yaml`
+   - `lib/parse_workload.py`
+   - `lib/slurm_pd_launcher.py`
+   - `lib/run.sh` and `lib/run_vllm_bench.sh`
+   - `lib/gpu_profiles.yaml`
+   - `.buildkite/generate_pipeline.py`
+   - `tests/test_parse_workload_serving.py`
+   - `tests/test_slurm_pd_launcher.py`
+4. Determine whether the task needs only a new workload or a schema/launcher change. Prefer a workload-only change when the existing schema can express the model and topology.
+
+## 2. Extract a model contract
+
+Translate the source recipe into an explicit contract before writing YAML:
+
+- model/checkpoint path and how compute nodes see it;
+- exact vLLM image or commit known to support the model;
+- precision or quantization and the KV-cache dtype actually safe for correctness;
+- common model flags, plus prefill-only and decode-only flags;
+- prefill and decode counts, nodes per instance, GPUs per node, TP, derived local/global DP, and EP intent;
+- NIXL, UCX, NCCL, Gloo, InfiniBand device, and socket-interface requirements;
+- router revision, binary path, policy, endpoint expansion, and ports;
+- first-start compilation/autotuning time and persistent cache requirements;
+- minimal smoke benchmark and the later representative performance cases.
+
+Do not silently guess a correctness-sensitive field. If the source does not establish KV-scale support, quantization compatibility, network devices, or the router revision, inspect the cluster/model artifacts or call out the uncertainty.
+
+## 3. Create the smallest viable workload
+
+1. Copy the closest PD workload and give the new recipe a model/hardware-specific name.
+2. Keep initial bring-up opt-in with `nightly: false`, `bench_only: true`, and a generous timeout.
+3. Put model flags shared by both roles in `serving.common_serve_args`; put scheduling flags in the relevant role's `serve_args`.
+4. Let the launcher own host, port, TP/DP ranks and addresses, hybrid load balancing, and KV-transfer JSON. Never duplicate its managed flags in workload arguments.
+5. Mount the model read-only, `/dev/infiniband`, and a persistent FlashInfer cache. Keep the Pyxis container writable when runtime compilation needs it.
+6. Use environment-overridable mount sources for site-specific paths.
+7. Add a tiny random smoke config before expensive throughput configs. The smoke case should be cheap enough to rerun while debugging startup and result ingestion.
+8. Set `vllm_bench.metadata` deliberately: device, precision, effective topology label, total serving GPUs, `disagg: true`, and `is_multinode: true`.
+
+Keep model-specific compromises documented next to the field. For example, if FP8 KV scales are unavailable or unreliable for the model loader, use a correct dtype such as BF16 and explain why.
+
+## 4. Prove topology and generated commands without GPUs
+
+Before allocating nodes:
+
+1. Verify the topology arithmetic and router expansion by hand using the reference formulas.
+2. Run the parser tests and launcher tests.
+3. Parse the workload with a stubbed lm-eval registry when needed.
+4. Feed the emitted normalized serving JSON to `lib/slurm_pd_launcher.py dry-run` and inspect every role instance, node command, mount, environment variable, endpoint, and allocation request.
+5. Add focused tests for any new topology or schema behavior. Assert generated commands and invariants, not implementation trivia.
+6. Run shell syntax checks for modified shell entry points.
+
+Do not start a GPU allocation while parser or dry-run validation is failing.
+
+## 5. Bring up locally on the Slurm cluster
+
+Use SSH on the login node before involving Buildkite.
+
+1. Confirm `sinfo`, `squeue`, `salloc`, `srun`, `scontrol`, Pyxis, shared checkout/results storage, model mount, router binary, and network devices.
+2. Export site-specific model/cache paths and Enroot cache/data/runtime paths.
+3. Start with the smoke workload via `./lib/run.sh <workload>` outside an existing allocation.
+4. Watch allocation state and the labeled prefill/decode step logs. Confirm all role health checks, router readiness, one successful request, raw benchmark JSON, and ingestion handling.
+5. Keep the first run alive long enough for kernel autotuning. Align `VLLM_ENGINE_READY_TIMEOUT_S`, role health deadlines, launcher wait time, Slurm time limit, and the persistent cache mount.
+6. On failure, gather the earliest causal error from the role or router that failed. Fix one layer at a time: allocation, container/mounts, model load, collectives, NIXL, role readiness, router, request, benchmark, ingestion.
+7. Confirm cleanup removes router and `srun` children and releases the allocation.
+
+Record the exact image digest/tag, router revision, topology, overrides, job ID, and outcome so the Buildkite run is reproducible.
+
+## 6. Validate performance and correctness separately
+
+- Treat server health and one successful response as bring-up, not correctness proof.
+- Run the smoke benchmark first, then one representative workload, then longer/high-concurrency cases.
+- Inspect warnings about KV scales, quantization fallback, unsupported kernels, collectives, and tokenizer/remote-code behavior.
+- Do not label numbers authoritative when the benchmark client shares serving resources or when the model uses an unvalidated cache dtype.
+- Preserve every benchmark configuration row and raw artifact; verify multiple configs do not collapse into one ingestion result.
+
+## 7. Exercise Buildkite only after local success
+
+1. If new hardware or a queue is required, update `lib/gpu_profiles.yaml`; do not hard-code queues in pipeline generation.
+2. Keep Slurm steps serialized per resolved queue because fixed router/DP RPC ports can collide.
+3. Ensure a one-worker Buildkite agent is online on the login-node queue and its environment hook exposes the cluster's Slurm configuration.
+4. Run repository tests and pre-commit checks, commit with the required AI co-author trailer, and push the feature branch.
+5. Trigger `vllm/perf-eval` for the exact pushed SHA and only the new workload. Pass both `VLLM_IMAGE` and `VLLM_COMMIT` as required by repository guidance.
+6. Report the build URL immediately. Tail failing job logs, diagnose the first causal failure, patch, revalidate locally where possible, push, and rerun once.
+7. Avoid duplicate GPU builds for the same commit.
+
+## 8. Finish the change
+
+Update `README.md` whenever the workload schema, repo layout, prerequisites, commands, queue setup, or supported topology changes. Keep reusable explanations generic and leave model-specific caveats in the workload.
+
+Hand off with:
+
+- files changed and whether the launcher/schema changed;
+- final topology and arithmetic;
+- local tests and Slurm job result;
+- Buildkite build URL/result, if run;
+- image/model/router revisions;
+- remaining correctness or measurement caveats;
+- branch, commit, and PR status.
+
+Include the repository-required AI-assistance disclosure in commit and PR metadata.

--- a/.agents/skills/vllm-pd-disagg-model-onboarding/agents/openai.yaml
+++ b/.agents/skills/vllm-pd-disagg-model-onboarding/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM PD Model Onboarding"
+  short_description: "Port and prove model-specific PD serving on Slurm"
+  default_prompt: "Use $vllm-pd-disagg-model-onboarding to add or debug a model-specific prefill/decode-disaggregated perf-eval workload, validate it locally on Slurm, and prepare a scoped Buildkite run."

--- a/.agents/skills/vllm-pd-disagg-model-onboarding/evals/evals.json
+++ b/.agents/skills/vllm-pd-disagg-model-onboarding/evals/evals.json
@@ -1,0 +1,44 @@
+{
+  "skill_name": "vllm-pd-disagg-model-onboarding",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add a manual perf-eval workload for a new 400B MoE checkpoint on the nvidia-b300-login Slurm cluster. The internal recipe uses one TP1/DP4 expert-parallel prefill instance and two TP4 expert-parallel decode replicas, NIXL, and a locally mounted checkpoint. Start with a cheap 8k-input smoke benchmark, prove it on the cluster, and prepare a scoped Buildkite run.",
+      "expected_output": "A model-specific workload and evidence-driven bring-up plan that reuses schema v1, computes the three-node/12-GPU topology correctly, validates generated commands, tests locally before Buildkite, and records correctness caveats.",
+      "files": [],
+      "expectations": [
+        "The response inspects the existing Kimi PD workload and launcher contract before editing.",
+        "The topology is calculated as one DEP4 prefill plus two TEP4 decode replicas on three four-GPU nodes.",
+        "The workload stays opt-in and includes a small smoke benchmark before large performance cases.",
+        "The plan validates parser and launcher dry-run output before requesting Slurm GPUs.",
+        "The plan requires local Slurm success before triggering the exact pushed commit in Buildkite."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Port an internal PD-disaggregated vLLM config for a dense model to perf-eval. It needs two prefill replicas and four decode replicas on eight-GPU nodes, but the source config does not say whether FP8 KV scales are calibrated or which mlx5 device this cluster uses. Please implement whatever is safe and tell me what remains blocked.",
+      "expected_output": "A conservative onboarding change that derives topology, distinguishes model and cluster unknowns, avoids guessing correctness-sensitive KV/network settings, and limits launcher changes to requirements the schema cannot already express.",
+      "files": [],
+      "expectations": [
+        "The response explicitly computes role and total node/GPU counts from count, nodes per instance, GPUs per node, and TP.",
+        "The response does not copy Kimi's network device or claim FP8 KV correctness without evidence.",
+        "The response uses a correctness-safe KV-cache choice or reports the missing decision as a blocker.",
+        "The response prefers a workload-only implementation when schema v1 already expresses the topology.",
+        "Any schema or launcher extension includes focused tests and a README update."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "The new Slurm PD Buildkite job allocates all nodes, but the prefill health check times out after 20 minutes while logs show FlashInfer kernel autotuning. A retry then reports the wrong number of router workers for asymmetric prefill/decode DP. Diagnose it and make the smallest reliable fix.",
+      "expected_output": "A layered diagnosis that persists compilation artifacts and aligns timeouts, then corrects asymmetric router endpoint expansion without masking real role or NIXL failures.",
+      "files": [],
+      "expectations": [
+        "The diagnosis separates first-start autotuning from allocation, model-load, NIXL, and router failures.",
+        "The fix persists the FlashInfer cache and aligns engine, role, launcher, Slurm, and Buildkite time budgets.",
+        "The router uses endpoint-level expansion for asymmetric local DP rather than expanding every URL by the prefill DP size.",
+        "The response reruns a cheap local smoke test before another shared GPU Buildkite build.",
+        "The response preserves failure-on-KV-load behavior and does not hide transfer errors."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/vllm-pd-disagg-model-onboarding/references/model-onboarding.md
+++ b/.agents/skills/vllm-pd-disagg-model-onboarding/references/model-onboarding.md
@@ -1,0 +1,231 @@
+# Model onboarding reference
+
+Use this reference while adapting a model to the schema-v1 Slurm PD path. `lib/parse_workload.py` and `lib/slurm_pd_launcher.py` remain the source of truth when this reference and code differ.
+
+## Topology arithmetic
+
+For each role:
+
+```text
+local_dp_size = gpus_per_node / tensor_parallel_size
+dp_size        = nodes_per_instance * local_dp_size
+role_nodes     = count * nodes_per_instance
+role_gpus      = count * nodes_per_instance * gpus_per_node
+```
+
+Across roles:
+
+```text
+total_nodes = sum(role_nodes)
+total_gpus  = sum(role_gpus)
+num_gpus    = total_gpus
+```
+
+`tensor_parallel_size` must divide `gpus_per_node` and currently stays within one node. Both roles use the same `gpus_per_node` inside one allocation.
+
+The Kimi baseline demonstrates asymmetric local DP:
+
+```text
+prefill: count 1 * one 4-GPU node, TP1 => local DP4 => DEP4
+decode:  count 2 * one 4-GPU node, TP4 => local DP1 => TEP4 x2
+total:   3 nodes, 12 GPUs
+```
+
+EP is enabled by vLLM serve arguments. The schema derives TP and DP; do not infer EP merely from the topology fields.
+
+## Router mapping
+
+Schema v1 uses:
+
+- `prefill_endpoints: all_instances`
+- `decode_endpoints: all_nodes`
+
+vllm-router v0.1.12 has one global `intra_node_data_parallel_size`. Set it to `1` when roles have different local DP sizes. This registers endpoint-level URLs: vLLM balances the prefill endpoint across its local DP ranks, while each TP decode replica remains one router worker.
+
+Only use a router DP expansion value above 1 when every role has the same local DP size. Otherwise the router expands prefill and decode URLs uniformly and invents invalid workers.
+
+Use fixed ports only with queue-level serialization. Check router, metrics, NIXL side-channel, and DP RPC port ranges for collisions.
+
+## Field checklist
+
+### Top level
+
+- `name`: unique model/hardware/PD identifier.
+- `gpu`: key in `lib/gpu_profiles.yaml`.
+- `num_gpus`: exact role-derived total.
+- `nightly: false`: keep experimental bring-up manual.
+- `bench_only: true`: skip accuracy suites while proving serving/perf flow.
+- `timeout_in_minutes`: cover queueing, image/model load, first compile, smoke benchmark, and cleanup.
+
+### `vllm`
+
+- `model`: in-container path or model ID visible to every role and the benchmark client.
+- `image`: pin the first known-compatible image. A newer tag is not automatically compatible with quantization, NIXL, router protocol, or the target GPU.
+- `env`: merge model and site runtime variables over the hardware profile.
+- Leave legacy `vllm.serve_args` empty for `pd_disagg`; use the serving fields below.
+
+### `serving.common_serve_args`
+
+Typical model decisions include:
+
+- expert parallelism and EP weight filtering;
+- remote code and language-model-only mode;
+- attention and MoE backends;
+- block size, max model length, memory utilization, prefix caching, and chunked prefill policy;
+- KV-cache dtype supported correctly by the checkpoint and loader;
+- eager mode versus CUDA graphs;
+- loading strategy and access logging.
+
+The launcher rejects orchestration flags it owns: host, port, TP/DP settings and ranks, hybrid load balancing, and KV-transfer config.
+
+### Role fields
+
+- `role`: exactly one `prefill` and one `decode` role object.
+- `count`: number of independent instances/replicas.
+- `nodes_per_instance`: nodes owned by each instance.
+- `gpus_per_node`: same for both roles.
+- `tensor_parallel_size`: divides GPUs per node.
+- `base_port`: node-local API port.
+- `kv_role`: `kv_producer` for prefill, `kv_consumer` for decode.
+- `serve_args`: scheduling and role-specific behavior only.
+- `health_check`: path, polling interval, and timeout large enough for first startup.
+
+### Slurm and Pyxis
+
+- `partition` and `time_limit` match the target cluster.
+- `grace_period_s` lets the controller stop router and role steps before forced cancellation.
+- Model mount is readable on every node and normally read-only in the container.
+- `/dev/infiniband` is exposed to the container for NIXL RDMA.
+- FlashInfer cache is persistent and mounted at `/root/.cache/flashinfer`.
+- Container is writable when vLLM/FlashInfer needs runtime compilation.
+- Checkout and results path are shared at the identical path because the benchmark client bind-mounts the repository.
+
+### Networking
+
+- Discover the actual IP interface and InfiniBand device on the target nodes; do not copy another cluster's values.
+- Keep NCCL and Gloo socket interfaces consistent with the routable fabric.
+- Use a UCX transport allow-list such as `rc,cuda_copy` when appropriate. A literal `^cuda_ipc` in an allow-list position can be resolved as a transport name instead of excluding it.
+- Set `UCX_MEMTYPE_CACHE=n` only when required by the tested stack.
+- Expose a unique `VLLM_NIXL_SIDE_CHANNEL_PORT` and let the launcher set the per-node side-channel host.
+- Validate that firewalls and cluster routing permit role endpoints and the login-node router path used by the benchmark client.
+
+### KV transfer
+
+- Schema v1 supports `NixlConnector`.
+- Use `load_failure_policy: fail` during bring-up so broken KV transfer cannot silently become a misleading benchmark.
+- Tune `extra_config.num_threads` only after correctness and basic transfer work.
+
+### Benchmark metadata
+
+- `device`: dashboard hardware label.
+- `precision`: model weight precision, not automatically the KV-cache dtype.
+- `tp`: document the effective decoder parallel/replica degree used for comparisons; explain non-obvious labels in a comment.
+- `total_gpus`: all serving GPUs participating in the end-to-end result.
+- `disagg: true` and `is_multinode: true`.
+
+## Staged validation
+
+### 1. Repository-only checks
+
+Run the focused suites first:
+
+```bash
+python3 -m unittest \
+  tests.test_parse_workload_serving \
+  tests.test_slurm_pd_launcher \
+  tests.test_run_vllm_bench \
+  tests.test_generate_pipeline \
+  tests.test_ingest_perf
+bash -n lib/run.sh
+bash -n lib/server.sh
+bash -n lib/run_lm_eval.sh
+bash -n lib/run_vllm_bench.sh
+```
+
+The repository's parser smoke-test pattern in `AGENTS.md` can stub `lm_eval.tasks.TaskManager`. Include every lm-eval task named by the target workload. Bench-only PD recipes may use an empty task registry.
+
+Capture normalized serving JSON without allowing shell evaluation of arbitrary output. One convenient inspection flow is:
+
+```bash
+python3 lib/parse_workload.py workloads/<model>_<hardware>_pd.yaml
+```
+
+Extract `WORKLOAD_SERVING_JSON` from the emitted shell assignments, then run:
+
+```bash
+python3 lib/slurm_pd_launcher.py --config '<normalized-json>' dry-run
+```
+
+Inspect:
+
+- `salloc` node/task/GPU request;
+- role instance ordering and node assignment;
+- TP/local DP/global DP and DP RPC ports;
+- per-node NIXL host and producer/consumer config;
+- Pyxis image, mounts, writable mode, workdir, and env;
+- router worker URLs and expansion;
+- benchmark client placement and router URL substitution.
+
+### 2. Login-node preflight
+
+Verify before consuming GPUs:
+
+```bash
+sinfo
+squeue -u "$USER"
+command -v salloc
+command -v srun
+command -v scontrol
+test -r "$MODEL_PATH"
+test -x "$ROUTER_REPO/target/release/vllm-router"
+```
+
+Also inspect the network interfaces and InfiniBand devices on an allocated node if the site values are not already established.
+
+### 3. Smoke run
+
+Export model, FlashInfer, and Enroot paths, then run the workload from the login node outside an allocation. Success means:
+
+1. one allocation with the expected nodes/GPUs;
+2. every prefill/decode instance becomes healthy;
+3. router becomes ready with the expected workers;
+4. one request completes through the router;
+5. the smoke benchmark writes valid JSON;
+6. ingestion is attempted with disaggregated/multinode metadata;
+7. cleanup releases all steps and the allocation.
+
+### 4. Buildkite
+
+- Push the exact commit before triggering.
+- Scope `WORKLOADS` to the new workload stem.
+- Pass the repository-required `VLLM_IMAGE` and `VLLM_COMMIT` values.
+- Verify the generated step targets the Slurm queue and is serialized by resolved queue.
+- Report the build URL, then use tail/search logs on only the failed job.
+
+## Failure guide
+
+| Symptom | Check first | Typical fix |
+| --- | --- | --- |
+| Allocation never starts | partition, account/QOS, requested nodes, queue state | Correct site allocation fields or wait; do not change serving flags. |
+| Pyxis container exits immediately | image pull, Enroot paths, mounts, writable mode | Fix image access/cache paths or the missing host path. |
+| Model load fails | checkpoint format, vLLM version, remote code, quantization kernels | Pin a compatible image and model flags; avoid unrelated topology changes. |
+| First health check times out | compilation/autotuning logs and cache mount | Persist cache and align engine, role, launcher, Slurm, and Buildkite timeouts. |
+| NCCL/Gloo bootstrap fails | socket interface and address reachability | Use the cluster's routable interface consistently. |
+| NIXL/UCX cannot initialize | `/dev/infiniband`, UCX device/transports, side-channel host/port | Expose devices and correct site-specific fabric settings. |
+| Router shows wrong workers | role counts, endpoint modes, global router DP expansion | Use endpoint-level expansion (`1`) for asymmetric local DP. |
+| Requests hang after prefill | producer/consumer KV roles, connector failure policy, NIXL logs | Fix transfer config before tuning performance. |
+| Output is numerically suspect | KV-scale warnings, quantization fallback, dtype support | Use a validated KV dtype or calibrated scale path and rerun correctness. |
+| Only first bench config runs | stdin consumed by Slurm/Pyxis child | Keep benchmark TSV on a dedicated file descriptor, as `lib/run.sh` does. |
+| Multiple rows overwrite/collapse | config name/artifact path/ingest metadata | Preserve a distinct raw result and ingestion call per config. |
+| Concurrent jobs collide | router or DP RPC ports shared on one queue | Serialize generated Slurm steps and keep the login-node agent at one worker. |
+
+## Change boundaries
+
+Prefer these scopes in order:
+
+1. New workload only.
+2. Workload plus existing hardware profile.
+3. Parser/schema extension with tests and README update.
+4. Launcher behavior change with plan tests, lifecycle tests, README update, and a regression build.
+
+Do not generalize the launcher from one model's unexplained flag. First decide whether the behavior is a model concern, cluster concern, topology concern, or truly orchestration-wide.

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -34,8 +34,11 @@ def setup_command(packages):
         f"  python -m pip install --upgrade {packages}\n"
         "else\n"
         "  rm -rf .venv\n"
-        "  (python3 -m ensurepip --user --upgrade --default-pip 2>/dev/null"
-        " || curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --user)\n"
+        "  if ! python3 -m pip --version >/dev/null 2>&1; then\n"
+        "    (python3 -m ensurepip --user --upgrade --default-pip 2>/dev/null"
+        " || curl -fsSL https://bootstrap.pypa.io/get-pip.py"
+        " | python3 - --user --break-system-packages)\n"
+        "  fi\n"
         f"  PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user --upgrade {packages}\n"
         "fi"
     )
@@ -45,10 +48,12 @@ FULL_SETUP_COMMANDS = [setup_command("'lm-eval[api]' pyyaml")]
 
 BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml")]
 
+# Dynamic pipeline uploads interpolate environment variables on the bootstrap
+# agent.  Escape these so HOME and PATH resolve on the GPU agent at job runtime.
 RUN_TEMPLATE = (
     'INGEST_BEARER_TOKEN="$(buildkite-agent secret get INGEST_BEARER_TOKEN)"'
     " && export INGEST_BEARER_TOKEN"
-    ' && export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$HOME/.local/bin:$PATH"'
+    ' && export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$$HOME/.local/bin:$$PATH"'
     " && ./lib/run.sh {path}"
 )
 
@@ -59,6 +64,7 @@ DEFAULT_IMAGE_REPO = "vllm/vllm-openai"
 GPU_EMOJI = {
     "H200": ":h200:",
     "B200": ":b200:",
+    "GB300": ":b300:",
     "A100": ":a100:",
     "MI355X": ":amd:",
     "MI300X": ":amd:",
@@ -286,7 +292,8 @@ def make_step(path, data, profiles):
         "commands": setup_commands + [RUN_TEMPLATE.format(path=path)],
         "artifact_paths": ["results/**/*"],
     }
-    if profile.get("server_runtime") == "native":
+    server_runtime = profile.get("server_runtime")
+    if server_runtime == "native":
         kind = profile.get("k8s_plugin")
         if not kind:
             sys.exit(
@@ -298,6 +305,17 @@ def make_step(path, data, profiles):
             sys.exit(f"{path}: unknown k8s_plugin {kind!r} (have {', '.join(K8S_PLUGINS)})")
         image = ecr_pull_through(resolved_image(data, profile))
         step["plugins"] = [builder(image, data.get("num_gpus", 1), profile, gpu)]
+    elif server_runtime == "slurm":
+        # The login-node router and several vLLM control-plane ports are fixed,
+        # so only one Slurm workload may target a queue at a time. Deriving the
+        # group from the resolved queue preserves isolation for queue overrides.
+        step.update(
+            {
+                "concurrency": 1,
+                "concurrency_group": f"perf-eval/{queue}",
+                "concurrency_method": "eager",
+            }
+        )
     step_env = {
         k: os.environ[k]
         for k in ("VLLM_IMAGE", "VLLM_COMMIT", "BENCH_ONLY")

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -51,7 +51,11 @@ BENCH_ONLY_SETUP_COMMANDS = [setup_command("pyyaml")]
 # Dynamic pipeline uploads interpolate environment variables on the bootstrap
 # agent.  Escape these so HOME and PATH resolve on the GPU agent at job runtime.
 RUN_TEMPLATE = (
-    'INGEST_BEARER_TOKEN="$(buildkite-agent secret get INGEST_BEARER_TOKEN)"'
+    # Fetch the ingest token only where the agent CLI is on PATH. On the Slurm
+    # login node it is not, and a hard failure here would abort the step before
+    # run.sh starts; ingestion is best-effort, so an empty token is fine.
+    'INGEST_BEARER_TOKEN="$(command -v buildkite-agent >/dev/null 2>&1'
+    ' && buildkite-agent secret get INGEST_BEARER_TOKEN || true)"'
     " && export INGEST_BEARER_TOKEN"
     ' && export HF_HOME="$(pwd)/.hf-cache" PATH="$(pwd)/.venv/bin:$$HOME/.local/bin:$$PATH"'
     " && ./lib/run.sh {path}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
-*.pyc
+*.py[cod]
+.bk.yaml
 .venv/
 .hf-cache/
 results/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # perf-eval
 
-Run accuracy + perf workloads against vLLM, defined by small YAML recipes in `workloads/`.
+Run accuracy + perf workloads against vLLM, defined by small YAML recipes in `workloads/`. Most recipes launch one vLLM server; opt-in schema-v1 recipes can instead launch a multi-node prefill/decode-disaggregated deployment through Slurm and Pyxis.
 
 Each recipe is one `(model, hardware, set of tasks)` combination. The Buildkite pipeline picks recipes up automatically — to ship a new run, you write a YAML file, push it, and trigger a build.
 
@@ -8,8 +8,9 @@ Each recipe is one `(model, hardware, set of tasks)` combination. The Buildkite 
 
 ```
 workloads/        one YAML per (model, hardware) recipe
-lib/              orchestrator (run.sh), helpers, GPU profiles
+lib/              orchestrator, server/Slurm launchers, helpers, GPU profiles
 .buildkite/       pipeline bootstrap, step generator, and its tests
+.agents/skills/   repo-scoped agent workflows, including PD model onboarding
 CLAUDE.md         agent conventions and detailed Buildkite workflow
 ```
 
@@ -30,6 +31,7 @@ GPU allocation; use at most 8 GPUs to keep the workload on one B200 node.
 A recipe has top-level metadata plus up to three eval blocks:
 
 - **`vllm:`** — *how the server runs.* Defines what model to serve and how (`model`, `serve_args`, optional image/env overrides). Required.
+- **`serving:`** — *optional multi-node orchestration.* Schema v1 supports Slurm/Pyxis prefill/decode disaggregation. Omit it for the existing standalone Docker/native path.
 - **`lm_eval:`** — *what accuracy to measure.* Lists lm-evaluation-harness tasks to run against the live server (e.g. `gsm8k`, `aime25`). Each task's score is saved under `results/<name>/<task-name>/`. Optional.
 - **`vllm_bench:`** — *what perf to measure.* Lists `vllm bench serve` configs (input/output lengths, concurrency, dataset). Raw JSON is saved and ingested into the perf dashboard. Optional.
 - **`bfcl:`** — *function-calling eval.* Runs [BFCL](https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard) test categories against the live server. Some models need `--enable-auto-tool-choice` and `--tool-call-parser` in `serve_args`. Results are transformed to lm_eval format and ingested as `bfcl_<category>` tasks. Optional.
@@ -110,6 +112,73 @@ A few things worth knowing:
 
 For everything else (the full set of supported fields, defaults, validation rules), the existing files in `workloads/` are the working reference and `lib/parse_workload.py` is the source of truth.
 
+### Slurm prefill/decode disaggregation
+
+`workloads/kimi_k3_gb300_pd.yaml` is the first schema-v1 example. It allocates three four-GPU GB300 nodes: one TP1 × DP4/EP prefill instance (DEP4) and two independent TP4 × DP1/EP decode replicas (TEP4×2). `num_gpus` must equal the total implied by the roles.
+
+The parser turns this block into a validated launch plan for `lib/slurm_pd_launcher.py`:
+
+```yaml
+serving:
+  version: 1
+  mode: pd_disagg
+  launcher: slurm
+  common_serve_args: >-
+    --enable-expert-parallel --enable-ep-weight-filter
+  slurm:
+    partition: batch
+    time_limit: "03:00:00"
+    grace_period_s: 120
+    container:
+      runtime: pyxis
+      mounts:
+        - source: /raid/shared/nvidia/Kimi-K3
+          source_env: KIMI_K3_MODEL_PATH
+          target: /model
+          read_only: true
+        - source: /dev/infiniband
+          target: /dev/infiniband
+        - source: /home/${USER}/.cache/flashinfer
+          source_env: FLASHINFER_CACHE_PATH
+          target: /root/.cache/flashinfer
+  kv_transfer:
+    connector: NixlConnector
+    load_failure_policy: fail
+    extra_config: {num_threads: 4}
+  roles:
+    - role: prefill
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      tensor_parallel_size: 1
+      kv_role: kv_producer
+    - role: decode
+      count: 2
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      tensor_parallel_size: 4
+      kv_role: kv_consumer
+  router:
+    repo_path: ${HOME}/Kimi-PD/vllm-router
+    revision: v0.1.12
+    command: [target/release/vllm-router]
+    port: 31000
+    nofile_limit: 8192
+    intra_node_data_parallel_size: 1
+```
+
+`tensor_parallel_size` defaults to 1 and must divide `gpus_per_node`; the launcher derives local DP as `gpus_per_node / tensor_parallel_size` and global DP as `nodes_per_instance × local DP`. It owns `--tensor-parallel-size`, `--port`, all global/local DP ranks and addresses, shared per-instance RPC ports, `--data-parallel-hybrid-lb`, and the NIXL KV-transfer JSON. Do not repeat those flags in `common_serve_args` or a role's `serve_args`.
+
+The serving state file records the allocation-owning controller PID and `grace_period_s`. Normal cleanup signals that controller first so it can stop the router and every `srun` cleanly; `scancel` is used only if the controller is unavailable or does not exit within the bounded shutdown wait.
+
+Router v0.1.12 has one global `intra_node_data_parallel_size`. Set it to `1` for mixed local DP sizes: the router treats each URL as one endpoint, vLLM internally balances the prefill endpoint across its four local DP ranks, and each TP4 decode replica remains one logical worker. Values above 1 are valid only when every role has the same local DP size, because the router expands both prefill and decode URLs uniformly.
+
+High-concurrency PD routing can require several sockets per in-flight request. Set `router.nofile_limit` high enough for the workload; the launcher raises its soft `RLIMIT_NOFILE` before starting the router and fails clearly if the requested value exceeds the process hard limit. The Kimi concurrency-3072 recipe uses `8192`, the hard limit available to the Buildkite agent on the GB300 Slurm login node.
+
+Mount `source_env` values make site-specific paths overridable without editing YAML. The Kimi workload accepts `KIMI_K3_MODEL_PATH` and `FLASHINFER_CACHE_PATH`. NIXL also requires `/dev/infiniband` inside the container. The checked-in GB300 settings match the `nvidia-b300-login` cluster (`mlx5_4:1` and `enP22p3s0f0np0`); other clusters should override the workload environment rather than copying the GB200 NVL72 settings.
+
+The Kimi workload uses BF16 KV cache because vLLM v0.25.1 does not load the checkpoint's calibrated FP8 KV scales for MLA models. Revisit FP8 only after the loader remap is fixed and correctness is revalidated.
+
 ### HF cache volume (Kubernetes profiles)
 
 For profiles that run in-pod on Kubernetes (`server_runtime: native` with a `k8s_plugin`), the HuggingFace cache is a named `hf-cache` volume mounted at the profile's `hf_home`. **By default it is an `emptyDir`** — scoped to the benchmark pod, so the cache is reclaimed when the pod exits and can never accumulate on the node's disk.
@@ -183,6 +252,21 @@ A real run needs a GPU host with Docker, vLLM, and lm-eval available:
 
 Locally, you can smoke-test recipe changes without a GPU — see `CLAUDE.md` for the parser stub and shell-syntax checks.
 
+For the GB300 Slurm recipe, run from a login-node shell outside any existing Slurm allocation, with `salloc`, `srun`, `scontrol`, Pyxis, and the v0.1.12 router binary already built at the configured path. The launcher owns and cancels one allocation, starts all role steps, then runs `vllm bench serve` inside the same image and allocation:
+
+```bash
+export KIMI_K3_MODEL_PATH=/raid/shared/nvidia/Kimi-K3
+export FLASHINFER_CACHE_PATH="$HOME/.cache/flashinfer"
+export ENROOT_CACHE_PATH="/raid/users/$USER/enroot-cache"
+export ENROOT_DATA_PATH="/raid/users/$USER/enroot-data"
+export ENROOT_RUNTIME_PATH="/tmp/enroot-$USER"
+./lib/run.sh workloads/kimi_k3_gb300_pd.yaml
+```
+
+The checkout and results directory must be on storage visible at the same path from the compute nodes; the benchmark client bind-mounts that path to persist its JSON artifact. For this first bring-up it runs as an overlapping CPU-only step on the first prefill node, so reported performance can include client-side contention; a dedicated client node is a follow-up for authoritative peak numbers. The `GB300` profile targets the `gb300-slurm` Buildkite login-node agent queue. This workload remains manual/opt-in (`nightly: false`); `GB300_QUEUE` can target an alternate cluster or canary queue. Generated Slurm steps are serialized with `concurrency: 1`, `concurrency_group: perf-eval/<resolved-queue>`, and `concurrency_method: eager`, preventing fixed router and DP RPC ports from colliding even if another agent is later attached to the queue. Keep the login-node agent itself at one worker as an additional guard. Its agent environment hook must put the cluster's Slurm binaries on `PATH` and set any site-required `SLURM_CONF` and `LD_LIBRARY_PATH`; the dynamic command defers `HOME` and `PATH` expansion until this GPU job runs. Before triggering the workload, ensure the queue has an online agent and the router/model prerequisites above are present.
+
 ## Agents
 
 `CLAUDE.md` has conventions for AI agents working in this repo: smoke-testing changes, launching Buildkite builds for a chosen branch/commit, and the AI-assistance disclosure rule for PRs and commits.
+
+For onboarding another model to the schema-v1 Slurm prefill/decode path, invoke the repository skill with `$vllm-pd-disagg-model-onboarding`. It captures the reusable model-contract, topology, NIXL/Pyxis, router, staged cluster bring-up, correctness, and Buildkite workflow behind `workloads/kimi_k3_gb300_pd.yaml`.

--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -15,6 +15,13 @@ B200:
     VLLM_DEEP_GEMM_WARMUP: skip
     NCCL_CUMEM_HOST_ENABLE: 0
 
+# Opt-in multi-node Slurm workloads. The queue is intentionally isolated from
+# the Kubernetes-backed B200 profile; set GB300_QUEUE only when targeting an
+# alternate cluster or canary agent queue.
+GB300:
+  queue: gb300-slurm
+  server_runtime: slurm
+
 MI300X:
   queue: mi300_perf_eval
   image_repo: vllm/vllm-openai-rocm

--- a/lib/ingest_perf.py
+++ b/lib/ingest_perf.py
@@ -8,9 +8,10 @@ here. Schema modeled after vllm-project/perf-dashboard/benchmark/process_result.
 
 Latencies in the raw result are in milliseconds (e.g., `mean_ttft_ms`).
 The dashboard expects seconds, so the transform drops the `_ms` suffix and
-divides by 1000. Aggregate throughput is divided by `tp` to match the
-dashboard's per-GPU columns (`tput_per_gpu`, `output_tput_per_gpu`,
-`input_tput_per_gpu`).
+divides by 1000. Aggregate throughput is divided by the total participating
+GPU count to match the dashboard's per-GPU columns (`tput_per_gpu`,
+`output_tput_per_gpu`, `input_tput_per_gpu`). This differs from the decoder's
+parallel degree for a prefill/decode-disaggregated deployment.
 
 Failures are logged but never fatal: ingestion is best-effort and must not
 abort the bench step.
@@ -52,6 +53,7 @@ def post(endpoint: str, payload: dict) -> None:
 def transform(raw: dict, args: argparse.Namespace) -> dict:
     """Map the raw `vllm bench serve` JSON to the dashboard's row shape."""
     tp = max(args.tp, 1)
+    gpu_count = max(getattr(args, "gpu_count", None) or tp, 1)
     total_token_throughput = float(raw.get("total_token_throughput", 0) or 0)
     output_throughput = float(raw.get("output_throughput", 0) or 0)
     input_throughput = total_token_throughput - output_throughput
@@ -65,16 +67,18 @@ def transform(raw: dict, args: argparse.Namespace) -> dict:
         "framework": "vllm",
         "precision": args.precision,
         "spec_decoding": "false",
-        "disagg": "false",
+        "disagg": str(bool(getattr(args, "disagg", False))).lower(),
         "isl": int(args.isl),
         "osl": int(args.osl),
-        "is_multinode": "false",
+        "is_multinode": str(
+            bool(getattr(args, "is_multinode", False))
+        ).lower(),
         "tp": tp,
         "ep": 1,
         "dp_attention": "false",
-        "tput_per_gpu": total_token_throughput / tp,
-        "output_tput_per_gpu": output_throughput / tp,
-        "input_tput_per_gpu": input_throughput / tp,
+        "tput_per_gpu": total_token_throughput / gpu_count,
+        "output_tput_per_gpu": output_throughput / gpu_count,
+        "input_tput_per_gpu": input_throughput / gpu_count,
     }
 
     if os.environ.get("NIGHTLY") == "1":
@@ -102,6 +106,18 @@ def main() -> int:
     p.add_argument("--raw-result", required=True, help="Raw JSON from `vllm bench serve --save-result`")
     p.add_argument("--device", required=True, help="Device tag (e.g. h200)")
     p.add_argument("--tp", type=int, required=True, help="Effective parallel-degree (TP * DP)")
+    p.add_argument(
+        "--gpu-count",
+        type=int,
+        default=None,
+        help="Total participating GPUs used for per-GPU throughput (default: --tp)",
+    )
+    p.add_argument(
+        "--disagg", action="store_true", help="Tag the result as disaggregated serving",
+    )
+    p.add_argument(
+        "--is-multinode", action="store_true", help="Tag the result as multi-node",
+    )
     p.add_argument("--precision", required=True, help="Precision tag (e.g. fp8, bf16)")
     p.add_argument("--model", required=True, help="HF model identifier (fallback if raw json lacks model_id)")
     p.add_argument("--image", required=True, help="Docker image used for the run")

--- a/lib/parse_workload.py
+++ b/lib/parse_workload.py
@@ -55,6 +55,34 @@ BFCL_KNOWN_CATEGORIES = {
     "live", "non_live", "non_python", "python", "memory", "agentic",
 }
 
+SERVING_FIELDS = {
+    "version", "mode", "launcher", "slurm", "kv_transfer",
+    "common_serve_args", "roles", "router",
+}
+SLURM_FIELDS = {"partition", "time_limit", "grace_period_s", "container"}
+CONTAINER_FIELDS = {"runtime", "mounts"}
+MOUNT_FIELDS = {"source", "source_env", "target", "read_only"}
+KV_TRANSFER_FIELDS = {"connector", "load_failure_policy", "extra_config"}
+ROLE_FIELDS = {
+    "role", "count", "nodes_per_instance", "gpus_per_node", "base_port",
+    "tensor_parallel_size", "kv_role", "serve_args", "env", "health_check",
+}
+ROUTER_FIELDS = {
+    "repo_path", "revision", "command", "policy", "listen_host",
+    "client_host", "port", "metrics_port", "nofile_limit",
+    "intra_node_data_parallel_size", "prefill_endpoints",
+    "decode_endpoints", "env", "health_check",
+}
+HEALTH_CHECK_FIELDS = {"path", "timeout_s", "poll_interval_s"}
+ORCHESTRATION_SERVE_FLAGS = {
+    "--port", "--data-parallel-size", "-dp", "--dp",
+    "--tensor-parallel-size", "-tp", "--tp",
+    "--data-parallel-size-local", "--data-parallel-address",
+    "--data-parallel-rpc-port", "--data-parallel-start-rank",
+    "--data-parallel-rank", "--data-parallel-hybrid-lb",
+    "--kv-transfer-config",
+}
+
 
 def emit(name: str, value: object) -> None:
     print(f"WORKLOAD_{name}={shlex.quote(str(value))}")
@@ -403,6 +431,586 @@ def bfcl_tsv(bfcl: dict) -> str:
     )
 
 
+def schema_error(path: str, location: str, message: str) -> None:
+    sys.exit(f"{path}: {location} {message}")
+
+
+def require_mapping(value: object, path: str, location: str) -> dict:
+    if not isinstance(value, dict):
+        schema_error(path, location, "must be a mapping")
+    return value
+
+
+def reject_unknown_fields(
+    value: dict, allowed: set, path: str, location: str,
+) -> None:
+    extra = set(value) - allowed
+    if extra:
+        schema_error(
+            path,
+            location,
+            f"has unsupported fields {sorted(str(k) for k in extra)}",
+        )
+
+
+def positive_int(value: object, path: str, location: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        schema_error(path, location, "must be a positive integer")
+    return value
+
+
+def boolean(value: object, path: str, location: str) -> bool:
+    if not isinstance(value, bool):
+        schema_error(path, location, "must be a boolean")
+    return value
+
+
+def port_number(value: object, path: str, location: str) -> int:
+    port = positive_int(value, path, location)
+    if port > 65535:
+        schema_error(path, location, "must be at most 65535")
+    return port
+
+
+def nonempty_string(value: object, path: str, location: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        schema_error(path, location, "must be a non-empty string")
+    return value
+
+
+def normalize_env(value: object, path: str, location: str) -> dict:
+    env = require_mapping(value, path, location)
+    normalized = {}
+    for key, raw_value in env.items():
+        if not isinstance(key, str) or not key:
+            schema_error(path, location, "keys must be non-empty strings")
+        if isinstance(raw_value, (dict, list)):
+            schema_error(path, f"{location}.{key}", "must be a scalar value")
+        normalized[key] = fmt(raw_value)
+    return normalized
+
+
+def split_argv(value: object, path: str, location: str) -> list:
+    if value in (None, ""):
+        return []
+    if not isinstance(value, str):
+        schema_error(path, location, "must be a shell-style argument string")
+    try:
+        return shlex.split(value)
+    except ValueError as e:
+        schema_error(path, location, f"is not valid shell-style syntax ({e})")
+
+
+def reject_orchestration_flags(argv: list, path: str, location: str) -> None:
+    for token in argv:
+        flag = token.partition("=")[0]
+        if flag in ORCHESTRATION_SERVE_FLAGS:
+            schema_error(
+                path,
+                location,
+                f"must not set launcher-owned flag {flag!r}",
+            )
+
+
+def normalize_health_check(
+    value: object,
+    path: str,
+    location: str,
+    *,
+    default_path: str = "/health",
+) -> dict:
+    health = require_mapping({} if value is None else value, path, location)
+    reject_unknown_fields(health, HEALTH_CHECK_FIELDS, path, location)
+
+    check_path = health.get("path", default_path)
+    if not isinstance(check_path, str) or not check_path.startswith("/"):
+        schema_error(path, f"{location}.path", "must start with '/'")
+
+    timeout_s = health.get("timeout_s", 1200)
+    timeout_s = positive_int(timeout_s, path, f"{location}.timeout_s")
+
+    poll_interval_s = health.get("poll_interval_s", 5)
+    if (isinstance(poll_interval_s, bool)
+            or not isinstance(poll_interval_s, (int, float))
+            or poll_interval_s <= 0):
+        schema_error(
+            path,
+            f"{location}.poll_interval_s",
+            "must be a positive number",
+        )
+
+    return {
+        "path": check_path,
+        "timeout_s": timeout_s,
+        "poll_interval_s": poll_interval_s,
+    }
+
+
+def normalize_mounts(value: object, path: str) -> list:
+    if value is None:
+        value = []
+    if not isinstance(value, list):
+        schema_error(path, "serving.slurm.container.mounts", "must be a list")
+
+    normalized = []
+    targets = set()
+    for i, raw_mount in enumerate(value):
+        location = f"serving.slurm.container.mounts[{i}]"
+        mount = require_mapping(raw_mount, path, location)
+        reject_unknown_fields(mount, MOUNT_FIELDS, path, location)
+
+        source = mount.get("source", "")
+        source_env = mount.get("source_env", "")
+        if source:
+            source = nonempty_string(source, path, f"{location}.source")
+        if source_env:
+            source_env = nonempty_string(
+                source_env, path, f"{location}.source_env",
+            )
+        if not source and not source_env:
+            schema_error(
+                path,
+                location,
+                "requires at least one of 'source' or 'source_env'",
+            )
+
+        target = nonempty_string(
+            mount.get("target"), path, f"{location}.target",
+        )
+        if not target.startswith("/"):
+            schema_error(path, f"{location}.target", "must be an absolute path")
+        if target in targets:
+            schema_error(path, location, f"duplicates mount target {target!r}")
+        targets.add(target)
+
+        read_only = mount.get("read_only", False)
+        if not isinstance(read_only, bool):
+            schema_error(path, f"{location}.read_only", "must be a boolean")
+        normalized.append({
+            "source": source,
+            "source_env": source_env,
+            "target": target,
+            "read_only": read_only,
+        })
+    return normalized
+
+
+def normalize_slurm(value: object, path: str) -> dict:
+    slurm = require_mapping(value, path, "serving.slurm")
+    reject_unknown_fields(slurm, SLURM_FIELDS, path, "serving.slurm")
+
+    partition = nonempty_string(
+        slurm.get("partition"), path, "serving.slurm.partition",
+    )
+    time_limit = nonempty_string(
+        slurm.get("time_limit"), path, "serving.slurm.time_limit",
+    )
+    grace_period_s = slurm.get("grace_period_s", 120)
+    if (isinstance(grace_period_s, bool)
+            or not isinstance(grace_period_s, int)
+            or grace_period_s < 0):
+        schema_error(
+            path,
+            "serving.slurm.grace_period_s",
+            "must be a non-negative integer",
+        )
+
+    container = require_mapping(
+        slurm.get("container"), path, "serving.slurm.container",
+    )
+    reject_unknown_fields(
+        container, CONTAINER_FIELDS, path, "serving.slurm.container",
+    )
+    runtime = container.get("runtime")
+    if runtime != "pyxis":
+        schema_error(
+            path,
+            "serving.slurm.container.runtime",
+            "must be 'pyxis' for schema version 1",
+        )
+
+    return {
+        "partition": partition,
+        "time_limit": time_limit,
+        "grace_period_s": grace_period_s,
+        "container": {
+            "runtime": runtime,
+            "mounts": normalize_mounts(container.get("mounts"), path),
+        },
+    }
+
+
+def normalize_kv_transfer(value: object, path: str) -> dict:
+    transfer = require_mapping(
+        {} if value is None else value, path, "serving.kv_transfer",
+    )
+    reject_unknown_fields(
+        transfer, KV_TRANSFER_FIELDS, path, "serving.kv_transfer",
+    )
+
+    connector = transfer.get("connector", "NixlConnector")
+    if connector != "NixlConnector":
+        schema_error(
+            path,
+            "serving.kv_transfer.connector",
+            "must be 'NixlConnector' for schema version 1",
+        )
+    policy = nonempty_string(
+        transfer.get("load_failure_policy", "fail"),
+        path,
+        "serving.kv_transfer.load_failure_policy",
+    )
+    raw_extra_config = transfer.get("extra_config")
+    extra_config = require_mapping(
+        {} if raw_extra_config is None else raw_extra_config,
+        path,
+        "serving.kv_transfer.extra_config",
+    )
+    try:
+        json.dumps(extra_config)
+    except (TypeError, ValueError) as e:
+        schema_error(
+            path,
+            "serving.kv_transfer.extra_config",
+            f"must be JSON-serializable ({e})",
+        )
+    return {
+        "connector": connector,
+        "load_failure_policy": policy,
+        "extra_config": extra_config,
+    }
+
+
+def normalize_role(
+    value: object, path: str, index: int, common_env: dict,
+) -> dict:
+    location = f"serving.roles[{index}]"
+    role = require_mapping(value, path, location)
+    reject_unknown_fields(role, ROLE_FIELDS, path, location)
+
+    role_name = role.get("role")
+    if role_name not in {"prefill", "decode"}:
+        schema_error(path, f"{location}.role", "must be 'prefill' or 'decode'")
+    count = positive_int(role.get("count"), path, f"{location}.count")
+    nodes = positive_int(
+        role.get("nodes_per_instance"),
+        path,
+        f"{location}.nodes_per_instance",
+    )
+    gpus = positive_int(
+        role.get("gpus_per_node"), path, f"{location}.gpus_per_node",
+    )
+    tensor_parallel_size = positive_int(
+        role.get("tensor_parallel_size", 1),
+        path,
+        f"{location}.tensor_parallel_size",
+    )
+    if tensor_parallel_size > gpus:
+        schema_error(
+            path,
+            f"{location}.tensor_parallel_size",
+            f"must stay within one node ({gpus} GPUs)",
+        )
+    if gpus % tensor_parallel_size:
+        schema_error(
+            path,
+            f"{location}.tensor_parallel_size",
+            f"must divide gpus_per_node ({gpus})",
+        )
+    local_dp_size = gpus // tensor_parallel_size
+    base_port = port_number(
+        role.get("base_port", 8000), path, f"{location}.base_port",
+    )
+
+    expected_kv_role = (
+        "kv_producer" if role_name == "prefill" else "kv_consumer"
+    )
+    kv_role = role.get("kv_role", expected_kv_role)
+    if kv_role != expected_kv_role:
+        schema_error(
+            path,
+            f"{location}.kv_role",
+            f"must be {expected_kv_role!r} for the {role_name} role",
+        )
+
+    serve_argv = split_argv(
+        role.get("serve_args"), path, f"{location}.serve_args",
+    )
+    reject_orchestration_flags(serve_argv, path, f"{location}.serve_args")
+
+    raw_role_env = role.get("env")
+    role_env = normalize_env(
+        {} if raw_role_env is None else raw_role_env,
+        path,
+        f"{location}.env",
+    )
+    return {
+        "role": role_name,
+        "count": count,
+        "nodes_per_instance": nodes,
+        "gpus_per_node": gpus,
+        "tensor_parallel_size": tensor_parallel_size,
+        "local_dp_size": local_dp_size,
+        "dp_size": nodes * local_dp_size,
+        "base_port": base_port,
+        "kv_role": kv_role,
+        "serve_argv": serve_argv,
+        "env": {**common_env, **role_env},
+        "health_check": normalize_health_check(
+            role.get("health_check"), path, f"{location}.health_check",
+        ),
+    }
+
+
+def normalize_router(
+    value: object, path: str, roles: list,
+) -> dict:
+    router = require_mapping(value, path, "serving.router")
+    reject_unknown_fields(router, ROUTER_FIELDS, path, "serving.router")
+
+    command = router.get("command", ["vllm-router"])
+    if isinstance(command, str):
+        command_argv = split_argv(command, path, "serving.router.command")
+    elif isinstance(command, list):
+        if not command or any(not isinstance(arg, str) or not arg for arg in command):
+            schema_error(
+                path,
+                "serving.router.command",
+                "must contain non-empty string arguments",
+            )
+        command_argv = list(command)
+    else:
+        schema_error(
+            path,
+            "serving.router.command",
+            "must be a string or list of strings",
+        )
+    if not command_argv:
+        schema_error(path, "serving.router.command", "must not be empty")
+
+    repo_path = nonempty_string(
+        router.get("repo_path"), path, "serving.router.repo_path",
+    )
+    revision = router.get("revision", "")
+    if not isinstance(revision, str):
+        schema_error(path, "serving.router.revision", "must be a string")
+
+    policy = nonempty_string(
+        router.get("policy", "round_robin"), path, "serving.router.policy",
+    )
+    listen_host = nonempty_string(
+        router.get("listen_host", "0.0.0.0"),
+        path,
+        "serving.router.listen_host",
+    )
+    client_host = nonempty_string(
+        router.get("client_host", "127.0.0.1"),
+        path,
+        "serving.router.client_host",
+    )
+    port = port_number(router.get("port", 31000), path, "serving.router.port")
+    nofile_limit = router.get("nofile_limit")
+    if nofile_limit is not None:
+        nofile_limit = positive_int(
+            nofile_limit, path, "serving.router.nofile_limit",
+        )
+
+    metrics_port = router.get("metrics_port")
+    if metrics_port is not None:
+        metrics_port = port_number(
+            metrics_port, path, "serving.router.metrics_port",
+        )
+        if metrics_port == port:
+            schema_error(
+                path,
+                "serving.router.metrics_port",
+                "must differ from serving.router.port",
+            )
+
+    intra_node_dp = positive_int(
+        router.get("intra_node_data_parallel_size", 1),
+        path,
+        "serving.router.intra_node_data_parallel_size",
+    )
+    local_dp_sizes = {role["local_dp_size"] for role in roles}
+    if intra_node_dp > 1 and local_dp_sizes != {intra_node_dp}:
+        schema_error(
+            path,
+            "serving.router.intra_node_data_parallel_size",
+            "values greater than 1 must equal local_dp_size for every role "
+            f"(have {sorted(local_dp_sizes)})",
+        )
+
+    prefill_endpoints = router.get("prefill_endpoints", "all_instances")
+    if prefill_endpoints != "all_instances":
+        schema_error(
+            path,
+            "serving.router.prefill_endpoints",
+            "must be 'all_instances' for schema version 1",
+        )
+    decode_endpoints = router.get("decode_endpoints", "all_nodes")
+    if decode_endpoints != "all_nodes":
+        schema_error(
+            path,
+            "serving.router.decode_endpoints",
+            "must be 'all_nodes' for schema version 1",
+        )
+
+    normalized = {
+        "repo_path": repo_path,
+        "revision": revision,
+        "command_argv": command_argv,
+        "policy": policy,
+        "listen_host": listen_host,
+        "client_host": client_host,
+        "port": port,
+        "intra_node_data_parallel_size": intra_node_dp,
+        "prefill_endpoints": prefill_endpoints,
+        "decode_endpoints": decode_endpoints,
+        "env": normalize_env(
+            {} if router.get("env") is None else router.get("env"),
+            path,
+            "serving.router.env",
+        ),
+        "health_check": normalize_health_check(
+            router.get("health_check"),
+            path,
+            "serving.router.health_check",
+            default_path="/readiness",
+        ),
+    }
+    if metrics_port is not None:
+        normalized["metrics_port"] = metrics_port
+    if nofile_limit is not None:
+        normalized["nofile_limit"] = nofile_limit
+    return normalized
+
+
+def normalize_serving(
+    serving_value: object,
+    data: dict,
+    profile: dict,
+    image: str,
+    path: str,
+) -> dict:
+    """Validate schema-v1 Slurm PD serving and return launcher-ready JSON data."""
+    serving = require_mapping(serving_value, path, "serving")
+    reject_unknown_fields(serving, SERVING_FIELDS, path, "serving")
+
+    version = serving.get("version")
+    if version != 1 or isinstance(version, bool):
+        schema_error(path, "serving.version", "must be integer 1")
+    if serving.get("mode") != "pd_disagg":
+        schema_error(path, "serving.mode", "must be 'pd_disagg'")
+    if serving.get("launcher") != "slurm":
+        schema_error(path, "serving.launcher", "must be 'slurm'")
+
+    vllm = require_mapping(data.get("vllm") or {}, path, "vllm")
+    model = nonempty_string(vllm.get("model"), path, "vllm.model")
+    legacy_serve_args = vllm.get("serve_args") or ""
+    if not isinstance(legacy_serve_args, str):
+        schema_error(path, "vllm.serve_args", "must be a string")
+    if legacy_serve_args.strip():
+        schema_error(
+            path,
+            "vllm.serve_args",
+            "must be empty when serving.mode is 'pd_disagg'; use "
+            "serving.common_serve_args and serving.roles[].serve_args",
+        )
+
+    profile_env = normalize_env(
+        {} if profile.get("env") is None else profile.get("env"),
+        path,
+        "gpu profile env",
+    )
+    workload_env = normalize_env(
+        {} if vllm.get("env") is None else vllm.get("env"),
+        path,
+        "vllm.env",
+    )
+    common_env = {**profile_env, **workload_env}
+    if "HF_HOME" not in common_env and profile.get("hf_home"):
+        common_env["HF_HOME"] = str(profile["hf_home"])
+
+    common_argv = split_argv(
+        serving.get("common_serve_args"),
+        path,
+        "serving.common_serve_args",
+    )
+    reject_orchestration_flags(
+        common_argv, path, "serving.common_serve_args",
+    )
+
+    raw_roles = serving.get("roles")
+    if not isinstance(raw_roles, list) or not raw_roles:
+        schema_error(path, "serving.roles", "must be a non-empty list")
+    roles_by_name = {}
+    for i, raw_role in enumerate(raw_roles):
+        role = normalize_role(raw_role, path, i, common_env)
+        role_name = role["role"]
+        if role_name in roles_by_name:
+            schema_error(
+                path,
+                "serving.roles",
+                f"must contain exactly one {role_name!r} role",
+            )
+        roles_by_name[role_name] = role
+    missing_roles = {"prefill", "decode"} - set(roles_by_name)
+    if missing_roles:
+        schema_error(
+            path,
+            "serving.roles",
+            "must contain exactly one 'prefill' and one 'decode' role",
+        )
+    roles = [roles_by_name["prefill"], roles_by_name["decode"]]
+
+    per_node_gpu_counts = {role["gpus_per_node"] for role in roles}
+    if len(per_node_gpu_counts) != 1:
+        schema_error(
+            path,
+            "serving.roles",
+            "must use the same gpus_per_node in one Slurm allocation",
+        )
+    gpus_per_node = next(iter(per_node_gpu_counts))
+    total_nodes = sum(
+        role["count"] * role["nodes_per_instance"] for role in roles
+    )
+    total_gpus = sum(
+        role["count"] * role["nodes_per_instance"] * role["gpus_per_node"]
+        for role in roles
+    )
+    declared_gpus = positive_int(
+        data.get("num_gpus"), path, "num_gpus",
+    )
+    if declared_gpus != total_gpus:
+        schema_error(
+            path,
+            "num_gpus",
+            f"is {declared_gpus}, but serving.roles require {total_gpus}",
+        )
+
+    return {
+        "version": version,
+        "mode": "pd_disagg",
+        "launcher": "slurm",
+        "model": model,
+        "image": image,
+        "total_nodes": total_nodes,
+        "total_gpus": total_gpus,
+        "gpus_per_node": gpus_per_node,
+        "common_env": common_env,
+        "common_argv": common_argv,
+        "slurm": normalize_slurm(serving.get("slurm"), path),
+        "kv_transfer": normalize_kv_transfer(
+            serving.get("kv_transfer"), path,
+        ),
+        "roles": roles,
+        "router": normalize_router(
+            serving.get("router"), path, roles,
+        ),
+    }
+
+
 def main(path: str) -> None:
     with open(path) as f:
         data = yaml.safe_load(f)
@@ -436,10 +1044,35 @@ def main(path: str) -> None:
     if "HF_HOME" not in env and profile.get("hf_home"):
         env["HF_HOME"] = profile["hf_home"]
 
+    serving = None
+    if "serving" in data:
+        serving = normalize_serving(
+            data.get("serving"), data, profile, image, path,
+        )
+
     metadata = bench.get("metadata") or {}
     tp = metadata.get("tp")
     if tp is None:
         tp = parse_tp(serve_args)
+    bench_gpu_count = metadata.get("total_gpus")
+    if bench_gpu_count is None:
+        bench_gpu_count = serving["total_gpus"] if serving is not None else tp
+    bench_gpu_count = positive_int(
+        bench_gpu_count, path, "vllm_bench.metadata.total_gpus",
+    )
+    bench_disagg = boolean(
+        metadata.get("disagg", serving is not None),
+        path,
+        "vllm_bench.metadata.disagg",
+    )
+    bench_is_multinode = boolean(
+        metadata.get(
+            "is_multinode",
+            serving is not None and serving["total_nodes"] > 1,
+        ),
+        path,
+        "vllm_bench.metadata.is_multinode",
+    )
 
     emit("NAME", data.get("name", ""))
     emit("IMAGE", image)
@@ -448,11 +1081,25 @@ def main(path: str) -> None:
     emit("SERVE_ARGS", serve_args)
     emit("SERVER_RUNTIME", profile.get("server_runtime", "docker"))
     emit("ENV", "\n".join(f"{k}={fmt(v)}" for k, v in env.items()))
+    if serving is not None:
+        emit("SERVING_MODE", serving["mode"])
+        emit(
+            "SERVING_JSON",
+            json.dumps(
+                serving,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
     emit("LM_EVAL_TASKS_TSV", task_tsv(tasks, lm_eval.get("model_args") or {}))
     emit("VLLM_BENCH_TSV", bench_tsv(bench_configs, path))
     emit("BFCL_TSV", bfcl_tsv(bfcl) if bfcl else "")
     emit("BENCH_DEVICE", metadata.get("device") or gpu.lower())
     emit("BENCH_TP", tp)
+    emit("BENCH_GPU_COUNT", bench_gpu_count)
+    emit("BENCH_DISAGG", str(bench_disagg).lower())
+    emit("BENCH_IS_MULTINODE", str(bench_is_multinode).lower())
     emit(
         "BENCH_PRECISION",
         metadata.get("precision") or precision_from_model(vllm.get("model") or ""),

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -17,12 +17,15 @@ source "$DIR/run_lm_eval.sh"
 source "$DIR/run_vllm_bench.sh"
 WORKLOAD_EXPORTS="$(python3 "$DIR/parse_workload.py" "$WORKLOAD")"
 eval "$WORKLOAD_EXPORTS"
+WORKLOAD_SERVING_MODE="${WORKLOAD_SERVING_MODE:-standalone}"
 export WORKLOAD_IMAGE WORKLOAD_VLLM_COMMIT WORKLOAD_SERVER_RUNTIME
+export WORKLOAD_SERVING_MODE WORKLOAD_SERVING_JSON
 
 PORT=8000
 CONTAINER="perf-eval-${WORKLOAD_NAME}-$$"
 RESULTS_DIR="results/${WORKLOAD_NAME}"
 BASE_URL="http://localhost:${PORT}"
+WORKLOAD_BENCH_BASE_URL="$BASE_URL"
 BENCH_TRUST_REMOTE_CODE=false
 if [[ "$WORKLOAD_SERVE_ARGS" =~ (^|[[:space:]])--trust-remote-code([[:space:]]|$) ]] ||
    [[ "$WORKLOAD_SERVE_ARGS" =~ (^|[[:space:]])--trust-remote-code=(true|True|1|yes|Yes)([[:space:]]|$) ]]; then
@@ -30,17 +33,87 @@ if [[ "$WORKLOAD_SERVE_ARGS" =~ (^|[[:space:]])--trust-remote-code([[:space:]]|$
 fi
 mkdir -p "$RESULTS_DIR"
 
-trap 'stop_server "$CONTAINER"' EXIT
+cleanup() {
+  local status=$?
+  set +e
+  if [[ "$WORKLOAD_SERVING_MODE" == "pd_disagg" ]]; then
+    local state_file="${PD_SERVING_STATE_FILE:-}"
+    local launcher="${PD_LAUNCHER:-$DIR/slurm_pd_launcher.py}"
+    local stopped=false
+    if [[ -n "$state_file" && -f "$state_file" ]]; then
+      if python3 "$launcher" --state-file "$state_file" stop; then
+        stopped=true
+      fi
+    fi
+    if [[ -n "${PD_SUPERVISOR_PID:-}" ]]; then
+      if [[ "$stopped" != true ]]; then
+        kill "$PD_SUPERVISOR_PID" 2>/dev/null || true
+      fi
+      wait "$PD_SUPERVISOR_PID" 2>/dev/null || true
+    fi
+  else
+    stop_server "$CONTAINER"
+  fi
+  return "$status"
+}
+trap cleanup EXIT
 
-start_server "$CONTAINER" "$PORT" "$WORKLOAD_IMAGE" "$WORKLOAD_MODEL" \
-             "$WORKLOAD_SERVE_ARGS" "$WORKLOAD_ENV" "$WORKLOAD_SERVER_RUNTIME"
-wait_healthy "$PORT"
+if [[ "$WORKLOAD_SERVING_MODE" == "pd_disagg" ]]; then
+  [[ "$WORKLOAD_SERVER_RUNTIME" == "slurm" ]] || {
+    echo "pd_disagg requires a GPU profile with server_runtime: slurm" >&2
+    exit 2
+  }
+  PD_LAUNCHER="$DIR/slurm_pd_launcher.py"
+  PD_SERVING_STATE_FILE="${RESULTS_DIR}/pd-serving-state.json"
+  export PD_LAUNCHER PD_SERVING_STATE_FILE WORKLOAD_BENCH_BASE_URL
+  rm -f "$PD_SERVING_STATE_FILE"
+
+  read -r ROUTER_CLIENT_HOST PORT < <(
+    python3 -c 'import json,sys; r=json.loads(sys.argv[1])["router"]; print(r["client_host"], r["port"])' \
+      "$WORKLOAD_SERVING_JSON"
+  )
+  BASE_URL="http://${ROUTER_CLIENT_HOST}:${PORT}"
+  # exec-client substitutes this with the login node's routable address from
+  # state before running vllm bench inside the allocation.
+  WORKLOAD_BENCH_BASE_URL='{router_url}'
+  export WORKLOAD_BENCH_BASE_URL
+
+  if python3 -c 'import json,sys; c=json.loads(sys.argv[1]); a=c["common_argv"] + sum((r["serve_argv"] for r in c["roles"]), []); sys.exit(0 if "--trust-remote-code" in a else 1)' \
+      "$WORKLOAD_SERVING_JSON"; then
+    BENCH_TRUST_REMOTE_CODE=true
+  fi
+
+  echo "--- :rocket: starting Slurm prefill/decode serving"
+  python3 "$PD_LAUNCHER" \
+    --config "$WORKLOAD_SERVING_JSON" \
+    --state-file "$PD_SERVING_STATE_FILE" \
+    supervise &
+  PD_SUPERVISOR_PID=$!
+  export PD_SUPERVISOR_PID
+  # Cover Slurm queueing, the longest role health deadline, and the router's
+  # sequential readiness check. First-run kernel tuning can use most of a
+  # workload's health-check budget.
+  python3 "$PD_LAUNCHER" \
+    --state-file "$PD_SERVING_STATE_FILE" \
+    wait-ready --timeout 4800 --supervisor-pid "$PD_SUPERVISOR_PID"
+  kill -0 "$PD_SUPERVISOR_PID" 2>/dev/null || {
+    echo "PD supervisor exited immediately after readiness" >&2
+    wait "$PD_SUPERVISOR_PID" || true
+    exit 1
+  }
+else
+  start_server "$CONTAINER" "$PORT" "$WORKLOAD_IMAGE" "$WORKLOAD_MODEL" \
+               "$WORKLOAD_SERVE_ARGS" "$WORKLOAD_ENV" "$WORKLOAD_SERVER_RUNTIME"
+  wait_healthy "$PORT"
+fi
 
 # vllm bench serve runs first so we can validate perf flow without waiting
 # on a full lm_eval pass. Each config's raw json lands in
 # $RESULTS_DIR/bench-<name>.json and is then transformed and POSTed to the
 # perf dashboard ingest endpoint.
-while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc repetitions speed_subset speed_category extra_args; do
+# Keep TSV input off stdin: Slurm/Pyxis clients may consume stdin and would
+# otherwise drain the remaining benchmark rows after the first config.
+while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc repetitions speed_subset speed_category extra_args <&3; do
   [[ -z "$bname" ]] && continue
   run_vllm_bench "$CONTAINER" "$PORT" "$WORKLOAD_MODEL" \
                  "$bname" "$backend" "$dataset" "$isl" "$osl" "$nprompts" \
@@ -48,22 +121,27 @@ while IFS=$'\t' read -r bname backend dataset isl osl nprompts conc repetitions 
                  "$extra_args" \
                  "$BENCH_TRUST_REMOTE_CODE" "$RESULTS_DIR"
 
-  python3 "$DIR/ingest_perf.py" \
-    --raw-result "${RESULTS_DIR}/bench-${bname}.json" \
-    --device "$WORKLOAD_BENCH_DEVICE" \
-    --tp "$WORKLOAD_BENCH_TP" \
-    --precision "$WORKLOAD_BENCH_PRECISION" \
-    --model "$WORKLOAD_MODEL" \
-    --image "$WORKLOAD_IMAGE" \
-    --isl "$isl" --osl "$osl" --conc "$conc" || true
-done <<< "$WORKLOAD_VLLM_BENCH_TSV"
+  ingest_args=(
+    --raw-result "${RESULTS_DIR}/bench-${bname}.json"
+    --device "$WORKLOAD_BENCH_DEVICE"
+    --tp "$WORKLOAD_BENCH_TP"
+    --gpu-count "$WORKLOAD_BENCH_GPU_COUNT"
+    --precision "$WORKLOAD_BENCH_PRECISION"
+    --model "$WORKLOAD_MODEL"
+    --image "$WORKLOAD_IMAGE"
+    --isl "$isl" --osl "$osl" --conc "$conc"
+  )
+  [[ "$WORKLOAD_BENCH_DISAGG" == "true" ]] && ingest_args+=(--disagg)
+  [[ "$WORKLOAD_BENCH_IS_MULTINODE" == "true" ]] && ingest_args+=(--is-multinode)
+  python3 "$DIR/ingest_perf.py" "${ingest_args[@]}" || true
+done 3<<< "$WORKLOAD_VLLM_BENCH_TSV"
 
 if [[ "${BENCH_ONLY:-}" =~ ^([Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss])$ ]]; then
   echo "--- :stopwatch: BENCH_ONLY set; skipping lm_eval and bfcl tasks"
   exit 0
 fi
 
-while IFS=$'\t' read -r task fewshot model_args; do
+while IFS=$'\t' read -r task fewshot model_args <&3; do
   [[ -z "$task" ]] && continue
   run_lm_eval "$WORKLOAD_MODEL" "$BASE_URL" "$task" "$fewshot" \
               "$model_args" "$RESULTS_DIR"
@@ -73,10 +151,10 @@ while IFS=$'\t' read -r task fewshot model_args; do
     --workload "$WORKLOAD_NAME" \
     --task "$task" \
     ${INGEST_NO_SAMPLES:+--no-samples} || true
-done <<< "$WORKLOAD_LM_EVAL_TASKS_TSV"
+done 3<<< "$WORKLOAD_LM_EVAL_TASKS_TSV"
 
 # bfcl function-calling eval
-while IFS=$'\t' read -r category num_threads temperature maximum_step_limit max_test_cases; do
+while IFS=$'\t' read -r category num_threads temperature maximum_step_limit max_test_cases <&3; do
   [[ -z "$category" ]] && continue
   echo "--- :phone: bfcl ${category}"
   python3 "$DIR/run_bfcl.py" "$WORKLOAD_MODEL" "$BASE_URL" \
@@ -100,4 +178,4 @@ while IFS=$'\t' read -r category num_threads temperature maximum_step_limit max_
       --task "bfcl_${category}" \
       --no-samples || true
   fi
-done <<< "$WORKLOAD_BFCL_TSV"
+done 3<<< "$WORKLOAD_BFCL_TSV"

--- a/lib/run_vllm_bench.sh
+++ b/lib/run_vllm_bench.sh
@@ -8,10 +8,10 @@
 #                  <repetitions> <extra_args_base64> <trust_remote_code> \
 #                  <output_dir>
 #
-# Docker runtime invokes `vllm bench serve` inside the vllm/vllm-openai
-# container via `docker exec`; native runtime invokes it directly. The raw
-# JSON lands in "<output_dir>/bench-<name>.json" so ingest_perf.py can pick
-# it up.
+# Docker runtime invokes `vllm bench serve` via `docker exec`; native runtime
+# invokes it directly. Slurm PD runtime delegates to slurm_pd_launcher.py so
+# the client runs in the serving allocation and Pyxis image. The raw JSON
+# lands in "<output_dir>/bench-<name>.json" so ingest_perf.py can pick it up.
 
 # vLLM's SpeedBench class expects a local <subset>.jsonl file built by
 # NeMo's prepare.py — the bench CLI does not download the dataset itself.
@@ -26,12 +26,9 @@ pip_install_quiet() {
   fi
 }
 
-append_bench_args() {
+decode_bench_args() {
   local encoded=$1
-  local -n command_ref=$2
-  local extra_args=()
-  mapfile -d '' -t extra_args < <(
-    python3 - "$encoded" <<'PY'
+  python3 - "$encoded" <<'PY'
 import base64
 import json
 import sys
@@ -58,8 +55,6 @@ for name, value in args.items():
         emit(flag)
         emit(json.dumps(value, separators=(",", ":")) if isinstance(value, dict) else value)
 PY
-  )
-  command_ref+=("${extra_args[@]}")
 }
 
 prepare_speed_bench_dataset() {
@@ -95,9 +90,14 @@ PY
   fi
   test -s "${data_dir}/${subset}.jsonl"
 
+  if [[ "$runtime" == "slurm" ]]; then
+    echo "SPEED-Bench is not yet supported by the Slurm client executor; use the random dataset" >&2
+    return 2
+  fi
+
   # Docker runtime: ship the data into the container and make sure pandas is
   # available there (vLLM's SpeedBench loads the JSONL via pandas).
-  if [[ "$runtime" != "native" ]]; then
+  if [[ "$runtime" == "docker" ]]; then
     docker exec "$container" mkdir -p "$data_dir"
     docker cp "${data_dir}/." "${container}:${data_dir}/"
     if ! docker exec "$container" python3 -c 'import pandas' 2>/dev/null; then
@@ -112,10 +112,20 @@ PY
 validate_bench_result() {
   local result_path=$1 expected=$2
   python3 - "$result_path" "$expected" <<'PY'
-import json, sys
+import json, sys, time
 path, expected = sys.argv[1], int(sys.argv[2])
-with open(path) as f:
-    result = json.load(f)
+# The client and validator may be different NFS clients. Allow one typical
+# attribute-cache window for the new file (or its completed contents) to show.
+deadline = time.monotonic() + 60
+while True:
+    try:
+        with open(path) as f:
+            result = json.load(f)
+        break
+    except (FileNotFoundError, json.JSONDecodeError):
+        if time.monotonic() >= deadline:
+            raise
+        time.sleep(1)
 def read_int(*keys, default=None):
     for k in keys:
         v = result.get(k)
@@ -139,7 +149,6 @@ run_vllm_bench() {
   local repetitions=${13} extra_args_base64=${14} trust_remote_code=${15}
   local outdir=${16}
   local runtime="${WORKLOAD_SERVER_RUNTIME:-docker}"
-  local host_json="${outdir}/bench-${name}.json"
 
   [[ "$backend" == "-" ]] && backend=""
   [[ "$speed_bench_dataset_subset" == "-" ]] && speed_bench_dataset_subset=""
@@ -147,13 +156,44 @@ run_vllm_bench() {
 
   echo "--- :stopwatch: vllm bench serve ${name} (dataset=${dataset} isl=${input_len} osl=${output_len} conc=${max_concurrency} n=${num_prompts} repetitions=${repetitions})"
   mkdir -p "$outdir"
+  local host_json
+  host_json="$(cd "$outdir" && pwd)/bench-${name}.json"
+  # Results can live on a shared filesystem. Never let a delayed writer from
+  # the current run race with a valid-looking result left by an earlier run.
+  rm -f "$host_json"
 
   local cmd=(vllm bench serve)
-  [[ "$runtime" != "native" ]] && cmd=(docker exec "$container" "${cmd[@]}")
+  case "$runtime" in
+    docker)
+      cmd=(docker exec "$container" "${cmd[@]}")
+      ;;
+    native)
+      ;;
+    slurm)
+      : "${PD_LAUNCHER:?PD_LAUNCHER is required for Slurm serving}"
+      : "${PD_SERVING_STATE_FILE:?PD_SERVING_STATE_FILE is required for Slurm serving}"
+      : "${WORKLOAD_SERVING_JSON:?WORKLOAD_SERVING_JSON is required for Slurm serving}"
+      cmd=(
+        python3 "$PD_LAUNCHER"
+        --config "$WORKLOAD_SERVING_JSON"
+        --state-file "$PD_SERVING_STATE_FILE"
+        exec-client --
+        "${cmd[@]}"
+      )
+      ;;
+    *)
+      echo "unsupported server runtime for vllm bench: $runtime" >&2
+      return 2
+      ;;
+  esac
 
   if [[ -n "$backend" ]]; then
-    cmd+=(--backend "$backend" --base-url "http://127.0.0.1:${port}")
+    local bench_base_url="${WORKLOAD_BENCH_BASE_URL:-http://127.0.0.1:${port}}"
+    cmd+=(--backend "$backend" --base-url "$bench_base_url")
     [[ "$backend" == "openai-chat" ]] && cmd+=(--endpoint /v1/chat/completions)
+  elif [[ "$runtime" == "slurm" ]]; then
+    # exec-client resolves these placeholders from allocation_router_url.
+    cmd+=(--host '{router_host}' --port '{router_port}')
   else
     cmd+=(--host 127.0.0.1 --port "$port")
   fi
@@ -195,30 +235,36 @@ run_vllm_bench() {
       ;;
   esac
 
-  append_bench_args "$extra_args_base64" cmd
+  local extra_arg
+  while IFS= read -r -d '' extra_arg; do
+    cmd+=("$extra_arg")
+  done < <(decode_bench_args "$extra_args_base64")
 
   local result_files=()
-  local repetition run_host_json run_container_json
+  local repetition run_host_json
   for ((repetition = 1; repetition <= repetitions; repetition++)); do
     if ((repetitions == 1)); then
       run_host_json="$host_json"
-      run_container_json="/tmp/bench-${name}.json"
     else
       run_host_json="${outdir}/bench-${name}-run-${repetition}.json"
-      run_container_json="/tmp/bench-${name}-run-${repetition}.json"
       echo "  repetition ${repetition}/${repetitions}"
     fi
 
     local run_cmd=("${cmd[@]}")
-    if [[ "$runtime" == "native" ]]; then
-      run_cmd+=(--save-result --result-filename "$run_host_json")
-    else
-      run_cmd+=(--save-result --result-filename "$run_container_json")
-    fi
+    case "$runtime" in
+      native|slurm)
+        # Native and Slurm run the client on the workload host, so it can
+        # write the result JSON straight into the results directory.
+        run_cmd+=(--save-result --result-filename "$run_host_json")
+        ;;
+      docker)
+        run_cmd+=(--save-result --result-filename "/tmp/bench-${name}-run-${repetition}.json")
+        ;;
+    esac
     "${run_cmd[@]}"
 
-    if [[ "$runtime" != "native" ]]; then
-      docker cp "${container}:${run_container_json}" "$run_host_json"
+    if [[ "$runtime" == "docker" ]]; then
+      docker cp "${container}:/tmp/bench-${name}-run-${repetition}.json" "$run_host_json"
     fi
     validate_bench_result "$run_host_json" "$num_prompts"
     result_files+=("$run_host_json")

--- a/lib/slurm_pd_launcher.py
+++ b/lib/slurm_pd_launcher.py
@@ -1,0 +1,1365 @@
+#!/usr/bin/env python3
+"""Launch schema-v1 vLLM prefill/decode serving in one Slurm allocation.
+
+The launcher accepts the normalized JSON emitted as ``WORKLOAD_SERVING_JSON``
+by ``parse_workload.py``.  It can also read JSON from ``--config`` (an inline
+object, a file path, or ``-`` for stdin).  The normal login-node flow is::
+
+    python3 lib/slurm_pd_launcher.py --config "$WORKLOAD_SERVING_JSON" \
+      --state-file results/pd-serving.json supervise
+
+When not already in an allocation, ``supervise`` re-execs itself under one
+``salloc``.  It then starts one overlapping ``srun`` per role instance, waits
+for every node-local API server, starts vllm-router, and remains in the
+foreground.  SIGINT/SIGTERM and child failure terminate every child step.
+
+``dry-run`` is deliberately Slurm-free and prints the complete deterministic
+plan.  It is also the primary local test surface for this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import resource
+import shlex
+import signal
+import socket
+import string
+import subprocess
+import sys
+import time
+from typing import Callable, Iterable, Mapping, Sequence
+from urllib import error as urlerror
+from urllib import parse as urlparse
+from urllib import request as urlrequest
+
+
+DP_RPC_PORT_BASE = 29500
+DEFAULT_STATE_FILE = "/tmp/perf-eval-pd-serving.json"
+FLASHINFER_CACHE_TARGET = "/root/.cache/flashinfer"
+INFINIBAND_TARGET = "/dev/infiniband"
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+DEFAULT_STOP_GRACE_S = 120
+MAX_STOP_WAIT_S = 300
+STOP_EXIT_SLACK_S = 10
+STOP_POLL_INTERVAL_S = 0.2
+
+MANAGED_SERVE_FLAGS = {
+    "--host",
+    "--port",
+    "--tensor-parallel-size",
+    "-tp",
+    "--tp",
+    "--data-parallel-size",
+    "-dp",
+    "--dp",
+    "--data-parallel-size-local",
+    "--data-parallel-address",
+    "--data-parallel-rpc-port",
+    "--data-parallel-start-rank",
+    "--data-parallel-rank",
+    "--kv-transfer-config",
+}
+HYBRID_LB_FLAG = "--data-parallel-hybrid-lb"
+SENSITIVE_ENV_MARKERS = ("TOKEN", "PASSWORD", "SECRET", "API_KEY")
+
+
+class ConfigError(ValueError):
+    """The normalized serving configuration is not launchable."""
+
+
+class LaunchError(RuntimeError):
+    """A Slurm step, health check, or router process failed."""
+
+
+class StopRequested(Exception):
+    """Internal control flow used to leave readiness waits on SIGINT/SIGTERM."""
+
+
+@dataclass
+class ChildProcess:
+    label: str
+    process: subprocess.Popen
+
+
+def _positive_int(value: object, location: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ConfigError(f"{location} must be a positive integer")
+    return value
+
+
+def _mapping(value: object, location: str) -> dict:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{location} must be an object")
+    return value
+
+
+def _argv(value: object, location: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(v, str) for v in value):
+        raise ConfigError(f"{location} must be an array of strings")
+    return list(value)
+
+
+def load_config(source: str | None, environ: Mapping[str, str] | None = None) -> dict:
+    """Load normalized serving JSON from inline text, a file, stdin, or env."""
+
+    env = os.environ if environ is None else environ
+    source = source or env.get("WORKLOAD_SERVING_JSON")
+    if not source:
+        raise ConfigError(
+            "missing serving config: pass --config or set WORKLOAD_SERVING_JSON"
+        )
+    if source == "-":
+        raw = sys.stdin.read()
+    elif source.lstrip().startswith("{"):
+        raw = source
+    else:
+        path = Path(source)
+        if not path.is_file():
+            raise ConfigError(f"serving config file does not exist: {source}")
+        raw = path.read_text()
+    try:
+        config = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"invalid serving JSON: {exc}") from exc
+    return validate_config(config)
+
+
+def validate_config(value: object) -> dict:
+    """Validate the launcher-facing subset of the normalized schema."""
+
+    config = _mapping(value, "serving config")
+    if config.get("version") != 1 or isinstance(config.get("version"), bool):
+        raise ConfigError("serving config version must be integer 1")
+    if config.get("mode") != "pd_disagg":
+        raise ConfigError("serving config mode must be 'pd_disagg'")
+    if config.get("launcher") != "slurm":
+        raise ConfigError("serving config launcher must be 'slurm'")
+    for key in ("model", "image"):
+        if not isinstance(config.get(key), str) or not config[key]:
+            raise ConfigError(f"serving config {key} must be a non-empty string")
+
+    total_nodes = _positive_int(config.get("total_nodes"), "total_nodes")
+    total_gpus = _positive_int(config.get("total_gpus"), "total_gpus")
+    gpus_per_node = _positive_int(
+        config.get("gpus_per_node"), "gpus_per_node"
+    )
+    _argv(config.get("common_argv", []), "common_argv")
+    _mapping(config.get("common_env", {}), "common_env")
+
+    slurm = _mapping(config.get("slurm"), "slurm")
+    for key in ("partition", "time_limit"):
+        if not isinstance(slurm.get(key), str) or not slurm[key]:
+            raise ConfigError(f"slurm.{key} must be a non-empty string")
+    grace = slurm.get("grace_period_s", 120)
+    if isinstance(grace, bool) or not isinstance(grace, int) or grace < 0:
+        raise ConfigError("slurm.grace_period_s must be a non-negative integer")
+    container = _mapping(slurm.get("container"), "slurm.container")
+    if container.get("runtime") != "pyxis":
+        raise ConfigError("slurm.container.runtime must be 'pyxis'")
+    mounts = container.get("mounts")
+    if not isinstance(mounts, list):
+        raise ConfigError("slurm.container.mounts must be an array")
+    mount_targets = set()
+    for index, raw_mount in enumerate(mounts):
+        mount = _mapping(raw_mount, f"slurm.container.mounts[{index}]")
+        target = mount.get("target")
+        if not isinstance(target, str) or not target.startswith("/"):
+            raise ConfigError(
+                f"slurm.container.mounts[{index}].target must be absolute"
+            )
+        if not mount.get("source") and not mount.get("source_env"):
+            raise ConfigError(
+                f"slurm.container.mounts[{index}] needs source or source_env"
+            )
+        mount_targets.add(target)
+    if INFINIBAND_TARGET not in mount_targets:
+        raise ConfigError(
+            f"slurm.container.mounts must expose {INFINIBAND_TARGET} for NIXL"
+        )
+    if FLASHINFER_CACHE_TARGET not in mount_targets:
+        raise ConfigError(
+            "slurm.container.mounts must include a persistent FlashInfer cache "
+            f"at {FLASHINFER_CACHE_TARGET}"
+        )
+
+    transfer = _mapping(config.get("kv_transfer"), "kv_transfer")
+    if transfer.get("connector") != "NixlConnector":
+        raise ConfigError("kv_transfer.connector must be 'NixlConnector'")
+    _mapping(transfer.get("extra_config", {}), "kv_transfer.extra_config")
+
+    roles = config.get("roles")
+    if not isinstance(roles, list) or len(roles) != 2:
+        raise ConfigError("roles must contain one prefill and one decode role")
+    role_names = {role.get("role") for role in roles if isinstance(role, dict)}
+    if role_names != {"prefill", "decode"}:
+        raise ConfigError("roles must contain one prefill and one decode role")
+    computed_nodes = 0
+    computed_gpus = 0
+    for index, raw_role in enumerate(roles):
+        role = _mapping(raw_role, f"roles[{index}]")
+        name = role["role"]
+        count = _positive_int(role.get("count"), f"roles[{index}].count")
+        nodes = _positive_int(
+            role.get("nodes_per_instance"),
+            f"roles[{index}].nodes_per_instance",
+        )
+        gpus = _positive_int(
+            role.get("gpus_per_node"), f"roles[{index}].gpus_per_node"
+        )
+        if gpus != gpus_per_node:
+            raise ConfigError(
+                f"roles[{index}].gpus_per_node must equal {gpus_per_node}"
+            )
+        tensor_parallel_size = _positive_int(
+            role.get("tensor_parallel_size"),
+            f"roles[{index}].tensor_parallel_size",
+        )
+        if tensor_parallel_size > gpus or gpus % tensor_parallel_size:
+            raise ConfigError(
+                f"roles[{index}].tensor_parallel_size must divide "
+                f"gpus_per_node ({gpus}) and stay within one node"
+            )
+        local_dp_size = gpus // tensor_parallel_size
+        if role.get("local_dp_size") != local_dp_size:
+            raise ConfigError(
+                f"roles[{index}].local_dp_size must equal gpus_per_node / "
+                f"tensor_parallel_size ({local_dp_size})"
+            )
+        expected_dp = nodes * local_dp_size
+        if role.get("dp_size") != expected_dp:
+            raise ConfigError(
+                f"roles[{index}].dp_size must equal nodes_per_instance * "
+                f"local_dp_size ({expected_dp})"
+            )
+        expected_kv_role = "kv_producer" if name == "prefill" else "kv_consumer"
+        if role.get("kv_role") != expected_kv_role:
+            raise ConfigError(
+                f"{name} kv_role must be {expected_kv_role!r}, not "
+                f"{role.get('kv_role')!r}"
+            )
+        port = _positive_int(role.get("base_port"), f"roles[{index}].base_port")
+        if port > 65535:
+            raise ConfigError(f"roles[{index}].base_port must be at most 65535")
+        _argv(role.get("serve_argv", []), f"roles[{index}].serve_argv")
+        _mapping(role.get("env", {}), f"roles[{index}].env")
+        health = _mapping(role.get("health_check"), f"roles[{index}].health_check")
+        if not isinstance(health.get("path"), str) or not health["path"].startswith("/"):
+            raise ConfigError(f"roles[{index}].health_check.path must start with /")
+        computed_nodes += count * nodes
+        computed_gpus += count * nodes * gpus
+    if computed_nodes != total_nodes or computed_gpus != total_gpus:
+        raise ConfigError(
+            "role topology does not match total_nodes/total_gpus "
+            f"({computed_nodes}/{computed_gpus} != {total_nodes}/{total_gpus})"
+        )
+
+    router = _mapping(config.get("router"), "router")
+    _argv(router.get("command_argv"), "router.command_argv")
+    if not router["command_argv"]:
+        raise ConfigError("router.command_argv must not be empty")
+    if not isinstance(router.get("repo_path"), str) or not router["repo_path"]:
+        raise ConfigError("router.repo_path must be a non-empty string")
+    _positive_int(router.get("port"), "router.port")
+    if router.get("nofile_limit") is not None:
+        _positive_int(router["nofile_limit"], "router.nofile_limit")
+    router_dp_size = _positive_int(
+        router.get("intra_node_data_parallel_size"),
+        "router.intra_node_data_parallel_size",
+    )
+    local_dp_sizes = {int(role["local_dp_size"]) for role in roles}
+    if router_dp_size != 1 and local_dp_sizes != {router_dp_size}:
+        raise ConfigError(
+            "router.intra_node_data_parallel_size must be 1 for endpoint-level "
+            "routing or equal every role's local_dp_size"
+        )
+    _mapping(router.get("health_check"), "router.health_check")
+    return config
+
+
+def _expand(value: str, environ: Mapping[str, str]) -> str:
+    expanded = string.Template(value).safe_substitute(environ)
+    if expanded.startswith("~"):
+        home = environ.get("HOME")
+        if home:
+            expanded = home + expanded[1:]
+        else:
+            expanded = os.path.expanduser(expanded)
+    return expanded
+
+
+def resolve_mounts(
+    config: Mapping[str, object], environ: Mapping[str, str] | None = None
+) -> list[dict]:
+    """Resolve source_env/fallback sources and ${USER}/${HOME} substitutions."""
+
+    env = os.environ if environ is None else environ
+    mounts = config["slurm"]["container"]["mounts"]
+    resolved = []
+    for mount in mounts:
+        source_env = mount.get("source_env", "")
+        source = env.get(source_env, "") if source_env else ""
+        source = source or mount.get("source", "")
+        source = _expand(str(source), env)
+        if not source or "$" in source:
+            raise ConfigError(
+                f"cannot resolve mount source for target {mount['target']!r}"
+            )
+        resolved.append(
+            {
+                "source": source,
+                "target": mount["target"],
+                "read_only": bool(mount.get("read_only", False)),
+            }
+        )
+    return resolved
+
+
+def normalize_image(image: str) -> str:
+    """Pyxis needs an explicit transport for ordinary Docker image names."""
+
+    return image if "://" in image else f"docker://{image}"
+
+
+def pyxis_mount_arg(mounts: Sequence[Mapping[str, object]]) -> str:
+    rendered = []
+    for mount in mounts:
+        item = f"{mount['source']}:{mount['target']}"
+        if mount.get("read_only"):
+            item += ":ro"
+        rendered.append(item)
+    return ",".join(rendered)
+
+
+def _clean_user_argv(argv: Sequence[str], location: str) -> list[str]:
+    """Reject launcher-owned flags; tolerate and deduplicate hybrid LB."""
+
+    cleaned = []
+    for token in argv:
+        flag = token.partition("=")[0]
+        if flag == HYBRID_LB_FLAG:
+            continue
+        if flag in MANAGED_SERVE_FLAGS:
+            raise ConfigError(f"{location} contains launcher-owned flag {flag!r}")
+        cleaned.append(token)
+    return cleaned
+
+
+def kv_transfer_config(config: Mapping[str, object], kv_role: str) -> str:
+    transfer = config["kv_transfer"]
+    payload = {
+        "kv_connector": transfer["connector"],
+        "kv_role": kv_role,
+        "kv_load_failure_policy": transfer.get("load_failure_policy", "fail"),
+        "kv_connector_extra_config": transfer.get("extra_config", {}),
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def vllm_argv(
+    config: Mapping[str, object],
+    role: Mapping[str, object],
+    *,
+    master_addr: str,
+    rpc_port: int,
+    start_rank: int | str,
+) -> list[str]:
+    """Build one node's vLLM command with every orchestration flag explicit."""
+
+    common = _clean_user_argv(config.get("common_argv", []), "common_argv")
+    role_args = _clean_user_argv(
+        role.get("serve_argv", []), f"{role['role']}.serve_argv"
+    )
+    argv = [
+        "vllm",
+        "serve",
+        config["model"],
+        *common,
+        *role_args,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(role["base_port"]),
+        "--tensor-parallel-size",
+        str(role["tensor_parallel_size"]),
+    ]
+    if int(role["dp_size"]) > 1:
+        argv.extend(
+            [
+                "--data-parallel-size",
+                str(role["dp_size"]),
+                "--data-parallel-size-local",
+                str(role["local_dp_size"]),
+                "--data-parallel-start-rank",
+                str(start_rank),
+                "--data-parallel-address",
+                master_addr,
+                "--data-parallel-rpc-port",
+                str(rpc_port),
+                HYBRID_LB_FLAG,
+            ]
+        )
+    argv.extend(
+        [
+            "--kv-transfer-config",
+            kv_transfer_config(config, str(role["kv_role"])),
+        ]
+    )
+    return argv
+
+
+def _expanded_env(
+    values: Mapping[str, object], environ: Mapping[str, str]
+) -> dict[str, str]:
+    return {key: _expand(str(value), environ) for key, value in values.items()}
+
+
+def _node_shell_script(
+    config: Mapping[str, object],
+    role: Mapping[str, object],
+    nodes: Sequence[str],
+    master_addr: str,
+    rpc_port: int,
+    mounts: Sequence[Mapping[str, object]],
+    environ: Mapping[str, str],
+) -> str:
+    cases = "\n".join(
+        f"  {shlex.quote(node)}) start_rank={index * role['local_dp_size']} ;;"
+        for index, node in enumerate(nodes)
+    )
+    command = vllm_argv(
+        config,
+        role,
+        master_addr=master_addr,
+        rpc_port=rpc_port,
+        start_rank="__START_RANK__",
+    )
+    marker = (
+        command.index("__START_RANK__")
+        if "__START_RANK__" in command
+        else -1
+    )
+    command_text = " ".join(
+        '"$start_rank"' if index == marker else shlex.quote(token)
+        for index, token in enumerate(command)
+    )
+    env = _expanded_env(role.get("env", {}), environ)
+    env_text = " ".join(
+        f"{shlex.quote(key)}={shlex.quote(value)}" for key, value in sorted(env.items())
+    )
+    if env_text:
+        command_text = f"env {env_text} {command_text}"
+    mount_checks = [
+        (
+            f"test -e {shlex.quote(str(mount['target']))} || "
+            "{ echo "
+            + shlex.quote(
+                f"required container path is missing: {mount['target']} "
+                f"(host source {mount['source']})"
+            )
+            + " >&2; exit 2; }"
+        )
+        for mount in mounts
+    ]
+    return "\n".join(
+        [
+            "set -euo pipefail",
+            'node="${SLURMD_NODENAME:-$(hostname -s)}"',
+            'case "$node" in',
+            cases,
+            '  *) echo "unexpected node: $node" >&2; exit 2 ;;',
+            "esac",
+            'export VLLM_NIXL_SIDE_CHANNEL_HOST="$node"',
+            *mount_checks,
+            f"exec {command_text}",
+        ]
+    )
+
+
+def _srun_argv(
+    config: Mapping[str, object],
+    role: Mapping[str, object],
+    nodes: Sequence[str],
+    mounts: Sequence[Mapping[str, object]],
+    shell_script: str,
+) -> list[str]:
+    return [
+        "srun",
+        "--overlap",
+        "--label",
+        "--kill-on-bad-exit=1",
+        f"--nodes={len(nodes)}",
+        f"--ntasks={len(nodes)}",
+        "--ntasks-per-node=1",
+        f"--nodelist={','.join(nodes)}",
+        f"--gpus-per-task={role['gpus_per_node']}",
+        f"--container-image={normalize_image(str(config['image']))}",
+        f"--container-mounts={pyxis_mount_arg(mounts)}",
+        "--container-writable",
+        "bash",
+        "-lc",
+        shell_script,
+    ]
+
+
+def _router_argv(
+    config: Mapping[str, object],
+    prefill_urls: Sequence[str],
+    decode_urls: Sequence[str],
+    environ: Mapping[str, str],
+) -> tuple[list[str], str, dict[str, str]]:
+    router = config["router"]
+    argv = [_expand(arg, environ) for arg in router["command_argv"]]
+    argv.extend(
+        [
+            "--policy",
+            router["policy"],
+            "--host",
+            router["listen_host"],
+            "--port",
+            str(router["port"]),
+            "--intra-node-data-parallel-size",
+            str(router["intra_node_data_parallel_size"]),
+            "--vllm-pd-disaggregation",
+        ]
+    )
+    if router.get("metrics_port") is not None:
+        argv.extend(["--prometheus-port", str(router["metrics_port"])])
+    for url in prefill_urls:
+        argv.extend(["--prefill", url])
+    for url in decode_urls:
+        argv.extend(["--decode", url])
+    cwd = _expand(router["repo_path"], environ)
+    env = _expanded_env(router.get("env", {}), environ)
+    return argv, cwd, env
+
+
+def build_launch_plan(
+    config: Mapping[str, object],
+    nodes: Sequence[str],
+    *,
+    environ: Mapping[str, str] | None = None,
+    controller_host: str | None = None,
+) -> dict:
+    """Assign nodes and return a deterministic, directly executable plan."""
+
+    config = validate_config(dict(config))
+    env = dict(os.environ if environ is None else environ)
+    if len(nodes) < config["total_nodes"]:
+        raise ConfigError(
+            f"allocation has {len(nodes)} nodes, need {config['total_nodes']}"
+        )
+    selected_nodes = list(nodes[: config["total_nodes"]])
+    if len(set(selected_nodes)) != len(selected_nodes):
+        raise ConfigError("allocation node list contains duplicates")
+    mounts = resolve_mounts(config, env)
+
+    role_instances = []
+    cursor = 0
+    rpc_offset = 0
+    for role in config["roles"]:
+        for instance_index in range(role["count"]):
+            stop = cursor + role["nodes_per_instance"]
+            instance_nodes = selected_nodes[cursor:stop]
+            cursor = stop
+            master_addr = instance_nodes[0]
+            rpc_port = DP_RPC_PORT_BASE + rpc_offset
+            rpc_offset += 1
+            node_commands = []
+            endpoints = []
+            for node_index, node in enumerate(instance_nodes):
+                start_rank = node_index * role["local_dp_size"]
+                argv = vllm_argv(
+                    config,
+                    role,
+                    master_addr=master_addr,
+                    rpc_port=rpc_port,
+                    start_rank=start_rank,
+                )
+                node_env = _expanded_env(role.get("env", {}), env)
+                node_env["VLLM_NIXL_SIDE_CHANNEL_HOST"] = node
+                node_commands.append(
+                    {
+                        "node": node,
+                        "start_rank": start_rank,
+                        "local_ranks": list(range(role["local_dp_size"])),
+                        "global_ranks": list(
+                            range(start_rank, start_rank + role["local_dp_size"])
+                        ),
+                        "argv": argv,
+                        "env": node_env,
+                    }
+                )
+                endpoints.append(f"http://{node}:{role['base_port']}")
+            script = _node_shell_script(
+                config, role, instance_nodes, master_addr, rpc_port, mounts, env
+            )
+            role_instances.append(
+                {
+                    "role": role["role"],
+                    "instance": instance_index,
+                    "nodes": instance_nodes,
+                    "master_addr": master_addr,
+                    "tensor_parallel_size": role["tensor_parallel_size"],
+                    "dp_size": role["dp_size"],
+                    "local_dp_size": role["local_dp_size"],
+                    "rpc_port": rpc_port,
+                    "port": role["base_port"],
+                    "kv_role": role["kv_role"],
+                    "node_commands": node_commands,
+                    "endpoints": endpoints,
+                    "health_check": dict(role["health_check"]),
+                    "srun_argv": _srun_argv(
+                        config, role, instance_nodes, mounts, script
+                    ),
+                }
+            )
+
+    prefill_instances = [
+        instance for instance in role_instances if instance["role"] == "prefill"
+    ]
+    decode_instances = [
+        instance for instance in role_instances if instance["role"] == "decode"
+    ]
+    # Schema v1 routes one URL per independent prefill instance and every
+    # node-local HTTP frontend in the multi-node decoder.
+    prefill_urls = [instance["endpoints"][0] for instance in prefill_instances]
+    decode_urls = [
+        url for instance in decode_instances for url in instance["endpoints"]
+    ]
+    host = controller_host or socket.gethostname()
+    router_argv, router_cwd, router_env = _router_argv(
+        config, prefill_urls, decode_urls, env
+    )
+    router = config["router"]
+    local_router_url = f"http://{router['client_host']}:{router['port']}"
+    routable_host = host if router["client_host"] in LOOPBACK_HOSTS else router["client_host"]
+    allocation_router_url = f"http://{routable_host}:{router['port']}"
+
+    workers = []
+    for instance in role_instances:
+        urls = (
+            [instance["endpoints"][0]]
+            if instance["role"] == "prefill"
+            else instance["endpoints"]
+        )
+        for url in urls:
+            node_index = instance["endpoints"].index(url)
+            workers.append(
+                {
+                    "role": instance["role"],
+                    "url": url,
+                    "node": instance["nodes"][node_index],
+                    "node_local_ranks": list(
+                        range(config["router"]["intra_node_data_parallel_size"])
+                    ),
+                    "global_start_rank": node_index * instance["local_dp_size"],
+                }
+            )
+
+    return {
+        "version": 1,
+        "allocation": {
+            "nodes": selected_nodes,
+            "total_nodes": config["total_nodes"],
+            "total_gpus": config["total_gpus"],
+            "gpus_per_node": config["gpus_per_node"],
+        },
+        "container": {
+            "image": normalize_image(config["image"]),
+            "writable": True,
+            "mounts": mounts,
+        },
+        "role_instances": role_instances,
+        "router": {
+            "argv": router_argv,
+            "cwd": router_cwd,
+            "env": router_env,
+            "nofile_limit": router.get("nofile_limit"),
+            "prefill_urls": prefill_urls,
+            "decode_urls": decode_urls,
+            "workers": workers,
+            "local_url": local_router_url,
+            "allocation_url": allocation_router_url,
+            "health_check": {
+                **router["health_check"],
+                "url": local_router_url + router["health_check"]["path"],
+            },
+        },
+    }
+
+
+def build_salloc_argv(
+    config: Mapping[str, object], state_file: str, script_path: str | None = None
+) -> list[str]:
+    """Build the single login-node allocation wrapper command."""
+
+    config = validate_config(dict(config))
+    script = script_path or str(Path(__file__).resolve())
+    return [
+        "salloc",
+        f"--nodes={config['total_nodes']}",
+        f"--ntasks={config['total_nodes']}",
+        "--ntasks-per-node=1",
+        f"--gpus-per-node={config['gpus_per_node']}",
+        f"--partition={config['slurm']['partition']}",
+        f"--time={config['slurm']['time_limit']}",
+        "--job-name=perf-eval-pd",
+        sys.executable,
+        script,
+        "--state-file",
+        str(Path(state_file).resolve()),
+        "--inside-allocation",
+        "supervise",
+    ]
+
+
+def discover_allocation_nodes(
+    environ: Mapping[str, str] | None = None,
+    check_output: Callable[..., str] = subprocess.check_output,
+) -> list[str]:
+    env = os.environ if environ is None else environ
+    node_expr = env.get("SLURM_JOB_NODELIST") or env.get("SLURM_NODELIST")
+    if not node_expr:
+        raise LaunchError("SLURM_JOB_NODELIST is not set inside the allocation")
+    try:
+        output = check_output(
+            ["scontrol", "show", "hostnames", node_expr], text=True
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise LaunchError(f"cannot expand Slurm node list {node_expr!r}: {exc}") from exc
+    nodes = [line.strip() for line in output.splitlines() if line.strip()]
+    if not nodes:
+        raise LaunchError(f"Slurm node list {node_expr!r} expanded to no nodes")
+    return nodes
+
+
+def _is_sensitive_key(key: str) -> bool:
+    upper = key.upper()
+    return any(marker in upper for marker in SENSITIVE_ENV_MARKERS)
+
+
+def redacted_plan(plan: Mapping[str, object]) -> dict:
+    """Return a dry-run-safe plan with secret environment values removed."""
+
+    result = copy.deepcopy(plan)
+    replacements = set()
+    for instance in result["role_instances"]:
+        for command in instance["node_commands"]:
+            for key, value in command["env"].items():
+                if _is_sensitive_key(key) and value:
+                    replacements.add(value)
+                    command["env"][key] = "<redacted>"
+    for key, value in result["router"]["env"].items():
+        if _is_sensitive_key(key) and value:
+            replacements.add(value)
+            result["router"]["env"][key] = "<redacted>"
+
+    def scrub(value: object) -> object:
+        if isinstance(value, str):
+            for secret in replacements:
+                value = value.replace(secret, "<redacted>")
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                value[index] = scrub(item)
+        elif isinstance(value, dict):
+            for key, item in value.items():
+                value[key] = scrub(item)
+        return value
+
+    return scrub(result)
+
+
+def _url_healthy(url: str, timeout_s: float = 2.0) -> bool:
+    try:
+        with urlrequest.urlopen(url, timeout=timeout_s) as response:
+            return 200 <= response.status < 300
+    except (OSError, urlerror.URLError):
+        return False
+
+
+def wait_for_checks(
+    checks: Sequence[Mapping[str, object]],
+    *,
+    process_guard: Callable[[], None] | None = None,
+    healthy: Callable[[str], bool] = _url_healthy,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Wait until every URL is healthy, retaining per-check deadlines."""
+
+    started = now()
+    pending = {check["url"]: dict(check) for check in checks}
+    deadlines = {
+        url: started + float(check.get("timeout_s", 1200))
+        for url, check in pending.items()
+    }
+    while pending:
+        if process_guard:
+            process_guard()
+        current = now()
+        for url, check in list(pending.items()):
+            if healthy(url):
+                del pending[url]
+                continue
+            if current >= deadlines[url]:
+                raise LaunchError(f"health check timed out: {url}")
+        if pending:
+            interval = min(
+                float(check.get("poll_interval_s", 5))
+                for check in pending.values()
+            )
+            sleep(interval)
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + f".tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, path)
+
+
+def _state_summary(
+    plan: Mapping[str, object],
+    children: Sequence[ChildProcess],
+    *,
+    ready: bool,
+    grace_period_s: int,
+) -> dict:
+    role_checks = []
+    for instance in plan["role_instances"]:
+        for endpoint in instance["endpoints"]:
+            role_checks.append(
+                {
+                    **instance["health_check"],
+                    "role": instance["role"],
+                    "instance": instance["instance"],
+                    "url": endpoint + instance["health_check"]["path"],
+                }
+            )
+    return {
+        "version": 1,
+        "ready": ready,
+        "job_id": os.environ.get("SLURM_JOB_ID", ""),
+        "owns_allocation": True,
+        "controller_host": socket.gethostname(),
+        "controller_pid": os.getpid(),
+        "grace_period_s": grace_period_s,
+        "nodes": plan["allocation"]["nodes"],
+        "role_checks": role_checks,
+        "router_check": plan["router"]["health_check"],
+        "router_url": plan["router"]["local_url"],
+        "allocation_router_url": plan["router"]["allocation_url"],
+        "router_port": int(plan["router"]["local_url"].rsplit(":", 1)[1]),
+        "children": [
+            {"label": child.label, "pid": child.process.pid} for child in children
+        ],
+    }
+
+
+class Supervisor:
+    """Own all role srun steps and the login-node router process."""
+
+    def __init__(
+        self,
+        config: Mapping[str, object],
+        plan: Mapping[str, object],
+        state_file: str,
+        *,
+        popen: Callable[..., subprocess.Popen] = subprocess.Popen,
+    ) -> None:
+        self.config = config
+        self.plan = plan
+        self.state_file = Path(state_file)
+        self.popen = popen
+        self.children: list[ChildProcess] = []
+        self.stop_requested = False
+        self.failure: str | None = None
+
+    def _write_state(self, ready: bool) -> None:
+        state = _state_summary(
+            self.plan,
+            self.children,
+            ready=ready,
+            grace_period_s=int(self.config["slurm"]["grace_period_s"]),
+        )
+        if self.failure:
+            state["error"] = self.failure
+        _write_json_atomic(self.state_file, state)
+
+    def _guard_children(self) -> None:
+        if getattr(self, "stop_requested", False):
+            raise StopRequested
+        for child in self.children:
+            status = child.process.poll()
+            if status is not None:
+                raise LaunchError(
+                    f"{child.label} exited unexpectedly with status {status}"
+                )
+
+    def request_stop(self, signum: int, _frame: object) -> None:
+        self.stop_requested = True
+
+    def _start_role_steps(self) -> None:
+        for instance in self.plan["role_instances"]:
+            label = f"{instance['role']}[{instance['instance']}]"
+            print(f"starting {label} on {','.join(instance['nodes'])}", flush=True)
+            process = self.popen(instance["srun_argv"], start_new_session=True)
+            self.children.append(ChildProcess(label, process))
+            self._write_state(ready=False)
+
+    def _start_router(self) -> None:
+        router = self.plan["router"]
+        router_env = os.environ.copy()
+        router_env.update(router["env"])
+        nofile_limit = router.get("nofile_limit")
+        if nofile_limit is not None:
+            soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+            if (
+                hard_limit != resource.RLIM_INFINITY
+                and nofile_limit > hard_limit
+            ):
+                raise LaunchError(
+                    f"router nofile_limit {nofile_limit} exceeds the process "
+                    f"hard limit {hard_limit}"
+                )
+            if soft_limit < nofile_limit:
+                try:
+                    resource.setrlimit(
+                        resource.RLIMIT_NOFILE,
+                        (nofile_limit, hard_limit),
+                    )
+                except (OSError, ValueError) as exc:
+                    raise LaunchError(
+                        f"cannot raise router nofile limit to {nofile_limit}: {exc}"
+                    ) from exc
+                print(
+                    f"raised router nofile soft limit from {soft_limit} "
+                    f"to {nofile_limit}",
+                    flush=True,
+                )
+        print(
+            f"starting router with {len(router['prefill_urls'])} prefill and "
+            f"{len(router['decode_urls'])} decode endpoints",
+            flush=True,
+        )
+        process = self.popen(
+            router["argv"],
+            cwd=router["cwd"],
+            env=router_env,
+            start_new_session=True,
+        )
+        self.children.append(ChildProcess("router", process))
+        self._write_state(ready=False)
+
+    def _role_checks(self) -> list[dict]:
+        return _state_summary(
+            self.plan,
+            self.children,
+            ready=False,
+            grace_period_s=int(self.config["slurm"]["grace_period_s"]),
+        )["role_checks"]
+
+    def run(self) -> int:
+        old_handlers = {}
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            old_handlers[signum] = signal.signal(signum, self.request_stop)
+        self._write_state(ready=False)
+        try:
+            self._start_role_steps()
+            wait_for_checks(self._role_checks(), process_guard=self._guard_children)
+            self._start_router()
+            wait_for_checks(
+                [self.plan["router"]["health_check"]],
+                process_guard=self._guard_children,
+            )
+            self._write_state(ready=True)
+            print(f"PD_ROUTER_URL={shlex.quote(self.plan['router']['local_url'])}")
+            print(f"PD_ROUTER_PORT={self.config['router']['port']}", flush=True)
+            while not self.stop_requested:
+                self._guard_children()
+                time.sleep(1)
+            return 0
+        except StopRequested:
+            self._write_state(ready=False)
+            return 0
+        except (ConfigError, LaunchError, OSError) as exc:
+            self.failure = str(exc)
+            self._write_state(ready=False)
+            print(f"PD serving failed: {exc}", file=sys.stderr, flush=True)
+            return 1
+        finally:
+            self.terminate_children(int(self.config["slurm"]["grace_period_s"]))
+            for signum, handler in old_handlers.items():
+                signal.signal(signum, handler)
+
+    def terminate_children(self, grace_period_s: int) -> None:
+        live = [child for child in reversed(self.children) if child.process.poll() is None]
+        for child in live:
+            try:
+                os.killpg(os.getpgid(child.process.pid), signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                pass
+        deadline = time.monotonic() + grace_period_s
+        while live and time.monotonic() < deadline:
+            live = [child for child in live if child.process.poll() is None]
+            if live:
+                time.sleep(0.2)
+        for child in live:
+            try:
+                os.killpg(os.getpgid(child.process.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+        for child in reversed(self.children):
+            try:
+                child.process.wait(timeout=2)
+            except (subprocess.TimeoutExpired, ChildProcessError):
+                pass
+
+
+def ensure_runtime_mounts(mounts: Sequence[Mapping[str, object]]) -> None:
+    """Create/validate only the login-visible persistent cache.
+
+    Model shards and RDMA devices may intentionally exist only on compute
+    nodes.  Every container task checks its resolved mount targets immediately
+    before vLLM starts instead of rejecting those valid node-local sources on
+    the controller.
+    """
+
+    for mount in mounts:
+        if mount["target"] == FLASHINFER_CACHE_TARGET:
+            source = Path(str(mount["source"]))
+            source.mkdir(parents=True, exist_ok=True)
+            if not source.is_dir():
+                raise LaunchError(
+                    f"FlashInfer cache is not a directory: {source}"
+                )
+
+
+def _parse_nodes(value: str | None, count: int) -> list[str]:
+    if value:
+        nodes = [item.strip() for item in value.split(",") if item.strip()]
+        if not nodes:
+            raise ConfigError("--nodes must contain at least one node")
+        return nodes
+    return [f"node{index:03d}" for index in range(count)]
+
+
+def _read_state(path: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text())
+    except FileNotFoundError as exc:
+        raise LaunchError(f"state file does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise LaunchError(f"state file is invalid JSON: {path}: {exc}") from exc
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return false for a missing process (and Linux zombies)."""
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+    # A dead background process can remain visible to kill(0) until its parent
+    # reaps it. The production launcher runs on Linux, where /proc exposes that
+    # state directly; other platforms conservatively treat it as alive.
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        close_paren = stat.rfind(")")
+        if close_paren >= 0 and stat[close_paren + 2 :].split(None, 1)[0] == "Z":
+            return False
+    except (OSError, IndexError):
+        pass
+    return True
+
+
+def wait_ready(
+    state_file: str,
+    timeout_s: float,
+    supervisor_pid: int | None = None,
+    *,
+    pid_alive: Callable[[int], bool] = _pid_alive,
+) -> dict:
+    deadline = time.monotonic() + timeout_s
+    state = None
+    while time.monotonic() < deadline:
+        try:
+            state = _read_state(state_file)
+        except LaunchError:
+            if supervisor_pid is not None and not pid_alive(supervisor_pid):
+                raise LaunchError(
+                    "PD supervisor exited before creating readiness state"
+                )
+            time.sleep(1)
+            continue
+        if state.get("error"):
+            raise LaunchError(str(state["error"]))
+        checks = [*state.get("role_checks", [])]
+        if state.get("router_check"):
+            checks.append(state["router_check"])
+        if state.get("ready") and checks and all(
+            _url_healthy(check["url"]) for check in checks
+        ):
+            return state
+        if supervisor_pid is not None and not pid_alive(supervisor_pid):
+            raise LaunchError("PD supervisor exited before readiness")
+        time.sleep(1)
+    raise LaunchError(f"PD serving was not ready within {timeout_s:g}s")
+
+
+def _stop_wait_s(state: Mapping[str, object]) -> float:
+    raw_grace = state.get("grace_period_s", DEFAULT_STOP_GRACE_S)
+    if isinstance(raw_grace, bool) or not isinstance(raw_grace, (int, float)):
+        raw_grace = DEFAULT_STOP_GRACE_S
+    grace = max(0.0, float(raw_grace))
+    return min(grace + STOP_EXIT_SLACK_S, MAX_STOP_WAIT_S)
+
+
+def _wait_for_pid_exit(
+    pid: int,
+    timeout_s: float,
+    *,
+    pid_alive: Callable[[int], bool],
+    now: Callable[[], float],
+    sleep: Callable[[float], None],
+) -> bool:
+    deadline = now() + timeout_s
+    while pid_alive(pid):
+        remaining = deadline - now()
+        if remaining <= 0:
+            return False
+        sleep(min(STOP_POLL_INTERVAL_S, remaining))
+    return True
+
+
+def stop_from_state(
+    state_file: str,
+    *,
+    pid_alive: Callable[[int], bool] = _pid_alive,
+    send_signal: Callable[[int, int], None] = os.kill,
+    run_command: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    now: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    state = _read_state(state_file)
+    if state.get("job_id"):
+        if not state.get("owns_allocation"):
+            raise LaunchError(
+                "refusing to cancel an allocation not owned by this launcher"
+            )
+
+        controller_pid = state.get("controller_pid")
+        controller_is_local = state.get("controller_host") == socket.gethostname()
+        if (
+            controller_is_local
+            and isinstance(controller_pid, int)
+            and not isinstance(controller_pid, bool)
+            and controller_pid > 0
+            and pid_alive(controller_pid)
+        ):
+            try:
+                send_signal(controller_pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                pass
+            else:
+                if _wait_for_pid_exit(
+                    controller_pid,
+                    _stop_wait_s(state),
+                    pid_alive=pid_alive,
+                    now=now,
+                    sleep=sleep,
+                ):
+                    return
+
+        result = run_command(["scancel", str(state["job_id"])], check=False)
+        if result.returncode:
+            raise LaunchError(
+                f"scancel failed for Slurm job {state['job_id']} "
+                f"with status {result.returncode}"
+            )
+        return
+    if state.get("controller_host") != socket.gethostname():
+        raise LaunchError("cannot stop local child PIDs from another controller host")
+    for child in reversed(state.get("children", [])):
+        try:
+            os.killpg(os.getpgid(int(child["pid"])), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+def build_client_srun_argv(
+    config: Mapping[str, object],
+    state: Mapping[str, object],
+    command: Sequence[str],
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    if not command:
+        raise ConfigError("exec-client requires a command after --")
+    if not state.get("job_id"):
+        raise LaunchError("state has no live Slurm job_id")
+    env = os.environ if environ is None else environ
+    mounts = resolve_mounts(config, env)
+    # Benchmark clients write JSON/result files relative to the checkout.
+    # Mounting the shared cwd at the identical path keeps those artifacts on
+    # the host and makes relative paths behave exactly as they do in run.sh.
+    checkout = str(Path.cwd().resolve())
+    if not any(mount["target"] == checkout for mount in mounts):
+        mounts.append(
+            {"source": checkout, "target": checkout, "read_only": False}
+        )
+    router_url = str(state["allocation_router_url"])
+    parsed_router_url = urlparse.urlsplit(router_url)
+    router_host = parsed_router_url.hostname
+    router_port = parsed_router_url.port
+    if not router_host or router_port is None:
+        raise LaunchError(
+            f"state has invalid allocation_router_url: {router_url!r}"
+        )
+    expanded_command = [
+        token.replace("{router_url}", router_url)
+        .replace("{router_host}", router_host)
+        .replace("{router_port}", str(router_port))
+        .replace("{model}", str(config["model"]))
+        for token in command
+    ]
+    return [
+        "srun",
+        "--overlap",
+        f"--jobid={state['job_id']}",
+        "--nodes=1",
+        "--ntasks=1",
+        f"--nodelist={state['nodes'][0]}",
+        f"--container-image={normalize_image(str(config['image']))}",
+        f"--container-mounts={pyxis_mount_arg(mounts)}",
+        "--container-writable",
+        f"--container-workdir={checkout}",
+        "env",
+        f"OPENAI_BASE_URL={router_url}",
+        f"PD_ROUTER_URL={router_url}",
+        "CUDA_VISIBLE_DEVICES=",
+        *expanded_command,
+    ]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        help="normalized JSON object, JSON file path, or - (defaults to WORKLOAD_SERVING_JSON)",
+    )
+    parser.add_argument(
+        "--state-file",
+        default=os.environ.get("PD_SERVING_STATE_FILE", DEFAULT_STATE_FILE),
+    )
+    parser.add_argument(
+        "--nodes", help="comma-separated nodes for dry-run (defaults to synthetic names)"
+    )
+    parser.add_argument("--inside-allocation", action="store_true", help=argparse.SUPPRESS)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("dry-run", help="print the deterministic launch plan")
+    subparsers.add_parser("supervise", help="allocate, launch, wait, and supervise")
+    ready = subparsers.add_parser("wait-ready", help="wait on an existing state file")
+    ready.add_argument("--timeout", type=float, default=1800)
+    ready.add_argument("--supervisor-pid", type=int)
+    subparsers.add_parser("stop", help="cancel the allocation recorded in state")
+    client = subparsers.add_parser(
+        "exec-client", help="run a client command in the serving allocation/image"
+    )
+    client.add_argument("client_command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = None
+    try:
+        if args.command == "wait-ready":
+            state = wait_ready(
+                args.state_file,
+                args.timeout,
+                supervisor_pid=args.supervisor_pid,
+            )
+            print(f"PD_ROUTER_URL={shlex.quote(state['router_url'])}")
+            print(f"PD_ROUTER_PORT={state['router_port']}")
+            return 0
+        if args.command == "stop":
+            stop_from_state(args.state_file)
+            return 0
+
+        config = load_config(args.config)
+        if args.command == "dry-run":
+            nodes = _parse_nodes(args.nodes, config["total_nodes"])
+            plan = build_launch_plan(config, nodes)
+            plan["allocation"]["salloc_argv"] = build_salloc_argv(
+                config, args.state_file
+            )
+            print(json.dumps(redacted_plan(plan), indent=2, sort_keys=True))
+            return 0
+
+        if args.command == "exec-client":
+            state = _read_state(args.state_file)
+            command = list(args.client_command)
+            if command and command[0] == "--":
+                command.pop(0)
+            client_argv = build_client_srun_argv(config, state, command)
+            return subprocess.run(client_argv).returncode
+
+        if args.command == "supervise" and not args.inside_allocation:
+            if os.environ.get("SLURM_JOB_ID"):
+                raise LaunchError(
+                    "refusing to adopt an ambient Slurm allocation; run the "
+                    "launcher from the login shell so it can own its allocation"
+                )
+            allocation_argv = build_salloc_argv(config, args.state_file)
+            allocation_env = os.environ.copy()
+            allocation_env["WORKLOAD_SERVING_JSON"] = json.dumps(
+                config, separators=(",", ":")
+            )
+            os.execvpe(allocation_argv[0], allocation_argv, allocation_env)
+
+        nodes = discover_allocation_nodes()
+        plan = build_launch_plan(config, nodes)
+        ensure_runtime_mounts(plan["container"]["mounts"])
+        return Supervisor(config, plan, args.state_file).run()
+    except (ConfigError, LaunchError, OSError) as exc:
+        if args.command == "supervise":
+            try:
+                _write_json_atomic(
+                    Path(args.state_file),
+                    {
+                        "version": 1,
+                        "ready": False,
+                        "job_id": (
+                            os.environ.get("SLURM_JOB_ID", "")
+                            if args.inside_allocation
+                            else ""
+                        ),
+                        "owns_allocation": bool(args.inside_allocation),
+                        "controller_host": socket.gethostname(),
+                        "controller_pid": os.getpid(),
+                        "grace_period_s": (
+                            int(config["slurm"]["grace_period_s"])
+                            if config is not None
+                            else DEFAULT_STOP_GRACE_S
+                        ),
+                        "error": str(exc),
+                    },
+                )
+            except OSError:
+                pass
+        print(f"slurm_pd_launcher: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_pipeline.py
+++ b/tests/test_generate_pipeline.py
@@ -1,0 +1,105 @@
+import importlib.util
+import os
+from pathlib import Path
+import unittest
+from unittest import mock
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GENERATOR_PATH = REPO_ROOT / ".buildkite" / "generate_pipeline.py"
+SPEC = importlib.util.spec_from_file_location("generate_pipeline", GENERATOR_PATH)
+generate_pipeline = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(generate_pipeline)
+
+
+class SlurmPipelineTests(unittest.TestCase):
+    def setUp(self):
+        self.path = "workloads/kimi_k3_gb300_pd.yaml"
+        with (REPO_ROOT / self.path).open() as f:
+            self.workload = yaml.safe_load(f)
+        self.profiles = generate_pipeline.load_profiles()
+
+    def test_pd_workload_uses_slurm_queue_without_kubernetes_plugin(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            step = generate_pipeline.make_step(
+                self.path, self.workload, self.profiles,
+            )
+
+        self.assertEqual(step["agents"]["queue"], "gb300-slurm")
+        self.assertEqual(step["timeout_in_minutes"], 240)
+        self.assertNotIn("plugins", step)
+        self.assertEqual(step["concurrency"], 1)
+        self.assertEqual(
+            step["concurrency_group"], "perf-eval/gb300-slurm",
+        )
+        self.assertEqual(step["concurrency_method"], "eager")
+        self.assertEqual(step["env"]["BENCH_ONLY"], "1")
+
+    def test_queue_can_be_overridden_for_agent_bringup(self):
+        with mock.patch.dict(
+            os.environ, {"GB300_QUEUE": "gb300-slurm-canary"}, clear=True,
+        ):
+            step = generate_pipeline.make_step(
+                self.path, self.workload, self.profiles,
+            )
+        self.assertEqual(step["agents"]["queue"], "gb300-slurm-canary")
+        self.assertEqual(
+            step["concurrency_group"], "perf-eval/gb300-slurm-canary",
+        )
+
+    def test_non_slurm_workload_has_no_serialization_guard(self):
+        workload = {
+            "name": "standalone-h200",
+            "gpu": "H200",
+            "bench_only": True,
+            "vllm": {"model": "example/model"},
+        }
+        with mock.patch.dict(os.environ, {}, clear=True):
+            step = generate_pipeline.make_step(
+                "workloads/standalone_h200.yaml", workload, self.profiles,
+            )
+
+        self.assertNotIn("concurrency", step)
+        self.assertNotIn("concurrency_group", step)
+        self.assertNotIn("concurrency_method", step)
+
+    def test_pd_workload_is_not_selected_by_default_nightly(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            selected = generate_pipeline.select_workloads(
+                [{"path": self.path, "data": self.workload}],
+            )
+        self.assertEqual(selected, [])
+
+    def test_setup_fallback_supports_externally_managed_python(self):
+        command = generate_pipeline.setup_command("pyyaml")
+
+        self.assertIn(
+            "if ! python3 -m pip --version >/dev/null 2>&1; then",
+            command,
+        )
+        self.assertIn(
+            "python3 - --user --break-system-packages",
+            command,
+        )
+        self.assertIn(
+            "PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user",
+            command,
+        )
+
+    def test_run_command_defers_agent_environment_until_job_runtime(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            step = generate_pipeline.make_step(
+                self.path, self.workload, self.profiles,
+            )
+
+        self.assertIn(
+            'PATH="$(pwd)/.venv/bin:$$HOME/.local/bin:$$PATH"',
+            step["commands"][-1],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ingest_perf.py
+++ b/tests/test_ingest_perf.py
@@ -1,0 +1,40 @@
+import argparse
+import unittest
+
+from lib import ingest_perf
+
+
+class IngestPerfTopologyTests(unittest.TestCase):
+    def test_disagg_uses_total_gpu_count_for_per_gpu_throughput(self):
+        raw = {
+            "total_token_throughput": 4000,
+            "output_throughput": 1200,
+            "max_concurrency": 3072,
+        }
+        args = argparse.Namespace(
+            tp=16,
+            gpu_count=40,
+            disagg=True,
+            is_multinode=True,
+            date="2026-07-14 00:00:00",
+            device="gb300",
+            conc=3072,
+            image="vllm:test",
+            model="/model",
+            precision="fp4",
+            isl=8192,
+            osl=1024,
+        )
+
+        transformed = ingest_perf.transform(raw, args)
+
+        self.assertEqual(transformed["tp"], 16)
+        self.assertEqual(transformed["disagg"], "true")
+        self.assertEqual(transformed["is_multinode"], "true")
+        self.assertEqual(transformed["tput_per_gpu"], 100)
+        self.assertEqual(transformed["output_tput_per_gpu"], 30)
+        self.assertEqual(transformed["input_tput_per_gpu"], 70)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parse_workload_serving.py
+++ b/tests/test_parse_workload_serving.py
@@ -1,0 +1,349 @@
+import contextlib
+import copy
+import io
+import json
+import os
+from pathlib import Path
+import shlex
+import tempfile
+import unittest
+from unittest import mock
+
+import yaml
+
+from lib import parse_workload
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def pd_workload() -> dict:
+    return {
+        "name": "kimi-k2.5-pd",
+        "gpu": "H200",
+        "num_gpus": 12,
+        "vllm": {
+            "model": "/model",
+            "image": "vllm/vllm-openai:v0.18.1-cu130",
+            "env": {
+                "SHARED": "common",
+                "VLLM_NIXL_SIDE_CHANNEL_PORT": 5600,
+            },
+        },
+        "serving": {
+            "version": 1,
+            "mode": "pd_disagg",
+            "launcher": "slurm",
+            "common_serve_args": (
+                "--trust-remote-code "
+                "--attention-config "
+                "'{\"use_trtllm_ragged_deepseek_prefill\":true}'"
+            ),
+            "slurm": {
+                "partition": "batch",
+                "time_limit": "03:00:00",
+                "grace_period_s": 120,
+                "container": {
+                    "runtime": "pyxis",
+                    "mounts": [
+                        {
+                            "source": "/raid/shared/nvidia/Kimi-K2.5-NVFP4",
+                            "source_env": "KIMI_K2_5_MODEL_PATH",
+                            "target": "/model",
+                            "read_only": True,
+                        },
+                        {
+                            "source": "/dev/infiniband",
+                            "target": "/dev/infiniband",
+                        },
+                    ],
+                },
+            },
+            "kv_transfer": {
+                "connector": "NixlConnector",
+                "load_failure_policy": "fail",
+                "extra_config": {"num_threads": 4},
+            },
+            "roles": [
+                {
+                    "role": "prefill",
+                    "count": 1,
+                    "nodes_per_instance": 1,
+                    "gpus_per_node": 4,
+                    "base_port": 8000,
+                    "kv_role": "kv_producer",
+                    "serve_args": "--enforce-eager --max-num-seqs 7",
+                    "env": {"SHARED": "prefill", "ROLE_ONLY": True},
+                    "health_check": {
+                        "path": "/health",
+                        "timeout_s": 1200,
+                        "poll_interval_s": 10,
+                    },
+                },
+                {
+                    "role": "decode",
+                    "count": 2,
+                    "nodes_per_instance": 1,
+                    "gpus_per_node": 4,
+                    "tensor_parallel_size": 4,
+                    "base_port": 8000,
+                    "kv_role": "kv_consumer",
+                    "serve_args": (
+                        "--max-num-seqs 256"
+                    ),
+                },
+            ],
+            "router": {
+                "repo_path": "${HOME}/Kimi-PD/vllm-router",
+                "revision": "v0.1.12",
+                "command": ["target/release/vllm-router"],
+                "policy": "round_robin",
+                "listen_host": "0.0.0.0",
+                "client_host": "127.0.0.1",
+                "port": 31000,
+                "metrics_port": 31001,
+                "nofile_limit": 65536,
+                "intra_node_data_parallel_size": 1,
+                "prefill_endpoints": "all_instances",
+                "decode_endpoints": "all_nodes",
+                "env": {"PROTOC": "${HOME}/.local/protoc/bin/protoc"},
+                "health_check": {
+                    "path": "/readiness",
+                    "timeout_s": 600,
+                    "poll_interval_s": 5,
+                },
+            },
+        },
+        "vllm_bench": {
+            "configs": [
+                {
+                    "name": "smoke",
+                    "input_len": 32,
+                    "output_len": 8,
+                    "num_prompts": 1,
+                    "max_concurrency": 1,
+                },
+            ],
+        },
+    }
+
+
+def emitted_value(stdout: str, name: str) -> str:
+    prefix = f"WORKLOAD_{name}="
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            values = shlex.split(line[len(prefix):])
+            return values[0] if values else ""
+    raise AssertionError(f"missing {prefix} in parser output")
+
+
+class ServingSchemaTests(unittest.TestCase):
+    def normalize(self, data: dict, image: str = "resolved:image") -> dict:
+        profile = {
+            "env": {"PROFILE_ENV": "profile", "SHARED": "profile"},
+            "hf_home": "/profile/hf",
+        }
+        return parse_workload.normalize_serving(
+            data["serving"], data, profile, image, "fixture.yaml",
+        )
+
+    def run_parser(self, data: dict, **environment: str) -> str:
+        tests_dir = REPO_ROOT / "tests"
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".yaml",
+            dir=tests_dir,
+            delete=False,
+        ) as f:
+            yaml.safe_dump(data, f, sort_keys=False)
+            path = Path(f.name)
+        try:
+            output = io.StringIO()
+            test_env = {"VLLM_IMAGE": "", "VLLM_COMMIT": "", **environment}
+            with mock.patch.dict(os.environ, test_env, clear=False):
+                with contextlib.redirect_stdout(output):
+                    parse_workload.main(str(path))
+            return output.getvalue()
+        finally:
+            path.unlink()
+
+    def test_normalizes_mixed_per_role_tp_and_dp(self):
+        normalized = self.normalize(pd_workload())
+
+        self.assertEqual(normalized["total_nodes"], 3)
+        self.assertEqual(normalized["total_gpus"], 12)
+        self.assertEqual(normalized["gpus_per_node"], 4)
+        self.assertEqual(normalized["common_env"]["SHARED"], "common")
+        self.assertEqual(normalized["common_env"]["HF_HOME"], "/profile/hf")
+        self.assertEqual(
+            normalized["common_argv"],
+            [
+                "--trust-remote-code",
+                "--attention-config",
+                '{"use_trtllm_ragged_deepseek_prefill":true}',
+            ],
+        )
+
+        prefill, decode = normalized["roles"]
+        self.assertEqual(
+            (
+                prefill["role"],
+                prefill["tensor_parallel_size"],
+                prefill["local_dp_size"],
+                prefill["dp_size"],
+            ),
+            ("prefill", 1, 4, 4),
+        )
+        self.assertEqual(
+            (
+                decode["role"],
+                decode["tensor_parallel_size"],
+                decode["local_dp_size"],
+                decode["dp_size"],
+            ),
+            ("decode", 4, 1, 1),
+        )
+        self.assertEqual(prefill["env"]["SHARED"], "prefill")
+        self.assertEqual(prefill["env"]["ROLE_ONLY"], "True")
+        self.assertEqual(decode["env"]["SHARED"], "common")
+        self.assertEqual(
+            normalized["slurm"]["container"]["mounts"][0]["source_env"],
+            "KIMI_K2_5_MODEL_PATH",
+        )
+        self.assertEqual(
+            normalized["router"]["command_argv"],
+            ["target/release/vllm-router"],
+        )
+        self.assertEqual(
+            normalized["router"]["intra_node_data_parallel_size"], 1,
+        )
+        self.assertEqual(normalized["router"]["nofile_limit"], 65536)
+
+    def test_pd_exports_compact_json_and_resolved_image(self):
+        stdout = self.run_parser(
+            pd_workload(), VLLM_IMAGE="registry.example/vllm:override",
+        )
+
+        self.assertEqual(emitted_value(stdout, "SERVING_MODE"), "pd_disagg")
+        serialized = emitted_value(stdout, "SERVING_JSON")
+        self.assertNotIn(": ", serialized)
+        self.assertNotIn(", ", serialized)
+        normalized = json.loads(serialized)
+        self.assertEqual(normalized["image"], "registry.example/vllm:override")
+        self.assertEqual(normalized["total_nodes"], 3)
+        self.assertEqual(emitted_value(stdout, "BENCH_GPU_COUNT"), "12")
+        self.assertEqual(emitted_value(stdout, "BENCH_DISAGG"), "true")
+        self.assertEqual(emitted_value(stdout, "BENCH_IS_MULTINODE"), "true")
+
+    def test_standalone_workload_emits_no_serving_exports(self):
+        data = pd_workload()
+        del data["serving"]
+        data["num_gpus"] = 1
+        data["vllm"]["serve_args"] = "--tensor-parallel-size 1"
+
+        stdout = self.run_parser(data)
+
+        self.assertNotIn("WORKLOAD_SERVING_", stdout)
+        self.assertEqual(
+            emitted_value(stdout, "SERVE_ARGS"),
+            "--tensor-parallel-size 1",
+        )
+        self.assertEqual(emitted_value(stdout, "BENCH_TP"), "1")
+        self.assertEqual(emitted_value(stdout, "BENCH_GPU_COUNT"), "1")
+        self.assertEqual(emitted_value(stdout, "BENCH_DISAGG"), "false")
+        self.assertEqual(emitted_value(stdout, "BENCH_IS_MULTINODE"), "false")
+
+    def test_rejects_invalid_pd_topologies_and_fields(self):
+        cases = []
+
+        wrong_total = pd_workload()
+        wrong_total["num_gpus"] = 11
+        cases.append((wrong_total, "serving.roles require 12"))
+
+        missing_decode = pd_workload()
+        missing_decode["serving"]["roles"].pop()
+        cases.append((missing_decode, "exactly one 'prefill' and one 'decode'"))
+
+        duplicate_prefill = pd_workload()
+        duplicate_prefill["serving"]["roles"][1]["role"] = "prefill"
+        duplicate_prefill["serving"]["roles"][1]["kv_role"] = "kv_producer"
+        cases.append((duplicate_prefill, "exactly one 'prefill' role"))
+
+        zero_count = pd_workload()
+        zero_count["serving"]["roles"][0]["count"] = 0
+        cases.append((zero_count, "count must be a positive integer"))
+
+        bad_launcher = pd_workload()
+        bad_launcher["serving"]["launcher"] = "local"
+        cases.append((bad_launcher, "launcher must be 'slurm'"))
+
+        bad_runtime = pd_workload()
+        bad_runtime["serving"]["slurm"]["container"]["runtime"] = "docker"
+        cases.append((bad_runtime, "must be 'pyxis'"))
+
+        unknown_role_field = pd_workload()
+        unknown_role_field["serving"]["roles"][0]["mystery"] = True
+        cases.append((unknown_role_field, "unsupported fields ['mystery']"))
+
+        legacy_args = pd_workload()
+        legacy_args["vllm"]["serve_args"] = "--max-num-seqs 1"
+        cases.append((legacy_args, "vllm.serve_args must be empty"))
+
+        launcher_arg = pd_workload()
+        launcher_arg["serving"]["roles"][1]["serve_args"] += " --port 9000"
+        cases.append((launcher_arg, "launcher-owned flag '--port'"))
+
+        hybrid_arg = pd_workload()
+        hybrid_arg["serving"]["roles"][1]["serve_args"] += (
+            " --data-parallel-hybrid-lb"
+        )
+        cases.append(
+            (hybrid_arg, "launcher-owned flag '--data-parallel-hybrid-lb'")
+        )
+
+        legacy_kv_role = pd_workload()
+        legacy_kv_role["serving"]["roles"][0]["kv_role"] = "kv_both"
+        cases.append((legacy_kv_role, "must be 'kv_producer'"))
+
+        zero_tp = pd_workload()
+        zero_tp["serving"]["roles"][0]["tensor_parallel_size"] = 0
+        cases.append((zero_tp, "tensor_parallel_size must be a positive integer"))
+
+        cross_node_tp = pd_workload()
+        cross_node_tp["serving"]["roles"][0]["tensor_parallel_size"] = 8
+        cases.append((cross_node_tp, "must stay within one node (4 GPUs)"))
+
+        uneven_tp = pd_workload()
+        uneven_tp["serving"]["roles"][0]["tensor_parallel_size"] = 3
+        cases.append((uneven_tp, "must divide gpus_per_node (4)"))
+
+        launcher_tp = pd_workload()
+        launcher_tp["serving"]["roles"][0]["serve_args"] += " --tp 2"
+        cases.append((launcher_tp, "launcher-owned flag '--tp'"))
+
+        incompatible_router_dp = pd_workload()
+        incompatible_router_dp["serving"]["router"][
+            "intra_node_data_parallel_size"
+        ] = 4
+        cases.append(
+            (
+                incompatible_router_dp,
+                "values greater than 1 must equal local_dp_size for every role",
+            )
+        )
+
+        invalid_nofile_limit = pd_workload()
+        invalid_nofile_limit["serving"]["router"]["nofile_limit"] = 0
+        cases.append(
+            (invalid_nofile_limit, "nofile_limit must be a positive integer")
+        )
+
+        for data, expected in cases:
+            with self.subTest(expected=expected):
+                with self.assertRaises(SystemExit) as raised:
+                    self.normalize(copy.deepcopy(data))
+                self.assertIn(expected, str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_vllm_bench.py
+++ b/tests/test_run_vllm_bench.py
@@ -1,0 +1,108 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SH = REPO_ROOT / "lib" / "run.sh"
+
+
+class RunVllmBenchTests(unittest.TestCase):
+    def test_orchestrator_keeps_tsv_rows_off_child_stdin(self):
+        run_script = RUN_SH.read_text()
+        self.assertEqual(run_script.count("<&3; do"), 3)
+        for variable in (
+            "WORKLOAD_VLLM_BENCH_TSV",
+            "WORKLOAD_LM_EVAL_TASKS_TSV",
+            "WORKLOAD_BFCL_TSV",
+        ):
+            self.assertIn(f'done 3<<< "${variable}"', run_script)
+
+        completed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                """
+                set -euo pipefail
+                rows=$'first\\nsecond\\nthird'
+                while IFS= read -r value <&3; do
+                  printf '%s\\n' "$value"
+                  cat >/dev/null
+                done 3<<< "$rows"
+                """,
+            ],
+            input="",
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.splitlines(), ["first", "second", "third"])
+
+    def test_waits_for_delayed_result_file_visibility(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin = temp_path / "bin"
+            fake_bin.mkdir()
+            fake_vllm = fake_bin / "vllm"
+            fake_vllm.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    result_file=""
+                    while (($#)); do
+                      if [[ "$1" == "--result-filename" ]]; then
+                        result_file=$2
+                        break
+                      fi
+                      shift
+                    done
+                    [[ -n "$result_file" ]]
+                    [[ ! -e "$result_file" ]]
+                    (
+                      sleep 0.2
+                      printf '{"completed": 1, "failed": 0}\n' >"$result_file"
+                    ) >/dev/null 2>&1 &
+                    """
+                )
+            )
+            fake_vllm.chmod(0o755)
+            results_path = temp_path / "results"
+            results_path.mkdir()
+            (results_path / "bench-delayed.json").write_text(
+                '{"completed": 1, "failed": 0, "stale": true}\n'
+            )
+
+            command = textwrap.dedent(
+                f"""\
+                set -euo pipefail
+                source {REPO_ROOT / 'lib' / 'run_vllm_bench.sh'}
+                export WORKLOAD_SERVER_RUNTIME=native
+                run_vllm_bench unused 8000 model delayed - random \\
+                  32 8 1 1 - - 1 e30= false {results_path}
+                """
+            )
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            completed = subprocess.run(
+                ["bash", "-c", command],
+                cwd=REPO_ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("saved", completed.stdout)
+            result = (results_path / "bench-delayed.json").read_text()
+            self.assertNotIn("stale", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_slurm_pd_launcher.py
+++ b/tests/test_slurm_pd_launcher.py
@@ -1,0 +1,602 @@
+import contextlib
+import copy
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from lib import slurm_pd_launcher as launcher
+
+
+def serving_config() -> dict:
+    common_env = {
+        "NCCL_SOCKET_IFNAME": "enP22p3s0f0np0",
+        "VLLM_NIXL_SIDE_CHANNEL_PORT": "5600",
+    }
+    return {
+        "version": 1,
+        "mode": "pd_disagg",
+        "launcher": "slurm",
+        "model": "/model",
+        "image": "vllm/vllm-openai:v0.18.1-cu130",
+        "total_nodes": 3,
+        "total_gpus": 12,
+        "gpus_per_node": 4,
+        "common_env": common_env,
+        "common_argv": ["--trust-remote-code", "--enforce-eager"],
+        "slurm": {
+            "partition": "batch",
+            "time_limit": "03:00:00",
+            "grace_period_s": 0,
+            "container": {
+                "runtime": "pyxis",
+                "mounts": [
+                    {
+                        "source": "/raid/shared/nvidia/Kimi-K2.5-NVFP4",
+                        "source_env": "KIMI_K2_5_MODEL_PATH",
+                        "target": "/model",
+                        "read_only": True,
+                    },
+                    {
+                        "source": "/dev/infiniband",
+                        "source_env": "",
+                        "target": "/dev/infiniband",
+                        "read_only": False,
+                    },
+                    {
+                        "source": "/home/${USER}/.cache/flashinfer",
+                        "source_env": "FLASHINFER_CACHE_PATH",
+                        "target": "/root/.cache/flashinfer",
+                        "read_only": False,
+                    },
+                ],
+            },
+        },
+        "kv_transfer": {
+            "connector": "NixlConnector",
+            "load_failure_policy": "fail",
+            "extra_config": {"num_threads": 4},
+        },
+        "roles": [
+            {
+                "role": "prefill",
+                "count": 1,
+                "nodes_per_instance": 1,
+                "gpus_per_node": 4,
+                "tensor_parallel_size": 1,
+                "local_dp_size": 4,
+                "dp_size": 4,
+                "base_port": 8000,
+                "kv_role": "kv_producer",
+                "serve_argv": ["--max-num-seqs", "7"],
+                "env": common_env,
+                "health_check": {
+                    "path": "/health",
+                    "timeout_s": 1200,
+                    "poll_interval_s": 10,
+                },
+            },
+            {
+                "role": "decode",
+                "count": 2,
+                "nodes_per_instance": 1,
+                "gpus_per_node": 4,
+                "tensor_parallel_size": 4,
+                "local_dp_size": 1,
+                "dp_size": 1,
+                "base_port": 8000,
+                "kv_role": "kv_consumer",
+                "serve_argv": ["--max-num-seqs", "256"],
+                "env": common_env,
+                "health_check": {
+                    "path": "/health",
+                    "timeout_s": 1200,
+                    "poll_interval_s": 10,
+                },
+            },
+        ],
+        "router": {
+            "repo_path": "${HOME}/Kimi-PD/vllm-router",
+            "revision": "v0.1.12",
+            "command_argv": ["target/release/vllm-router"],
+            "policy": "round_robin",
+            "listen_host": "0.0.0.0",
+            "client_host": "127.0.0.1",
+            "port": 31000,
+            "metrics_port": 31001,
+            "nofile_limit": 65536,
+            "intra_node_data_parallel_size": 1,
+            "prefill_endpoints": "all_instances",
+            "decode_endpoints": "all_nodes",
+            "env": {"PROTOC": "${HOME}/.local/protoc/bin/protoc"},
+            "health_check": {
+                "path": "/readiness",
+                "timeout_s": 600,
+                "poll_interval_s": 5,
+            },
+        },
+    }
+
+
+def option_value(argv: list[str], option: str) -> str:
+    index = argv.index(option)
+    return argv[index + 1]
+
+
+class PlanTests(unittest.TestCase):
+    def setUp(self):
+        self.config = serving_config()
+        self.nodes = [f"c{index:02d}" for index in range(2, 5)]
+        self.env = {
+            "HOME": "/home/inf-kevin",
+            "USER": "inf-kevin",
+            "KIMI_K2_5_MODEL_PATH": "/raid/models/kimi",
+        }
+        self.plan = launcher.build_launch_plan(
+            self.config,
+            self.nodes,
+            environ=self.env,
+            controller_host="slogin-01",
+        )
+
+    def test_assigns_one_dep4_prefill_then_two_tep4_decoders(self):
+        instances = self.plan["role_instances"]
+        self.assertEqual(len(instances), 3)
+        self.assertEqual(
+            [instance["nodes"] for instance in instances],
+            [["c02"], ["c03"], ["c04"]],
+        )
+        prefill, decode0, decode1 = instances
+        self.assertEqual(
+            (prefill["tensor_parallel_size"], prefill["dp_size"]),
+            (1, 4),
+        )
+        for decode in (decode0, decode1):
+            self.assertEqual(decode["role"], "decode")
+            self.assertEqual(
+                (decode["tensor_parallel_size"], decode["dp_size"]),
+                (4, 1),
+            )
+            self.assertEqual(decode["node_commands"][0]["global_ranks"], [0])
+
+    def test_dep_prefill_gets_dp_flags_while_tep_decoders_do_not(self):
+        prefill, *decoders = self.plan["role_instances"]
+        prefill_argv = prefill["node_commands"][0]["argv"]
+        self.assertEqual(option_value(prefill_argv, "--tensor-parallel-size"), "1")
+        self.assertEqual(option_value(prefill_argv, "--data-parallel-size"), "4")
+        self.assertEqual(
+            option_value(prefill_argv, "--data-parallel-size-local"), "4"
+        )
+        self.assertEqual(
+            option_value(prefill_argv, "--data-parallel-rpc-port"), "29500"
+        )
+        self.assertEqual(prefill_argv.count("--data-parallel-hybrid-lb"), 1)
+
+        for decode in decoders:
+            argv = decode["node_commands"][0]["argv"]
+            self.assertEqual(option_value(argv, "--tensor-parallel-size"), "4")
+            self.assertNotIn("--data-parallel-size", argv)
+            self.assertNotIn("--data-parallel-size-local", argv)
+            self.assertNotIn("--data-parallel-rpc-port", argv)
+            self.assertNotIn("--data-parallel-hybrid-lb", argv)
+
+    def test_role_specific_nixl_configs_and_per_node_hosts(self):
+        for instance in self.plan["role_instances"]:
+            expected_role = (
+                "kv_producer" if instance["role"] == "prefill" else "kv_consumer"
+            )
+            for command in instance["node_commands"]:
+                transfer = json.loads(
+                    option_value(command["argv"], "--kv-transfer-config")
+                )
+                self.assertEqual(transfer["kv_connector"], "NixlConnector")
+                self.assertEqual(transfer["kv_role"], expected_role)
+                self.assertEqual(
+                    command["env"]["VLLM_NIXL_SIDE_CHANNEL_HOST"],
+                    command["node"],
+                )
+
+    def test_router_registers_endpoint_level_prefill_and_decode_replicas(self):
+        router = self.plan["router"]
+        self.assertEqual(router["prefill_urls"], ["http://c02:8000"])
+        self.assertEqual(
+            router["decode_urls"], ["http://c03:8000", "http://c04:8000"]
+        )
+        self.assertEqual(len(router["workers"]), 3)
+        self.assertTrue(
+            all(worker["node_local_ranks"] == [0] for worker in router["workers"])
+        )
+        self.assertEqual(router["argv"].count("--prefill"), 1)
+        self.assertEqual(router["argv"].count("--decode"), 2)
+        self.assertEqual(
+            option_value(router["argv"], "--intra-node-data-parallel-size"),
+            "1",
+        )
+        self.assertEqual(option_value(router["argv"], "--prometheus-port"), "31001")
+        self.assertEqual(router["cwd"], "/home/inf-kevin/Kimi-PD/vllm-router")
+        self.assertEqual(router["local_url"], "http://127.0.0.1:31000")
+        self.assertEqual(router["allocation_url"], "http://slogin-01:31000")
+        self.assertEqual(router["nofile_limit"], 65536)
+
+    def test_pyxis_is_writable_and_preserves_required_mounts(self):
+        self.assertEqual(
+            self.plan["container"]["image"],
+            "docker://vllm/vllm-openai:v0.18.1-cu130",
+        )
+        mounts = self.plan["container"]["mounts"]
+        self.assertIn(
+            {"source": "/dev/infiniband", "target": "/dev/infiniband", "read_only": False},
+            mounts,
+        )
+        self.assertIn(
+            {
+                "source": "/home/inf-kevin/.cache/flashinfer",
+                "target": "/root/.cache/flashinfer",
+                "read_only": False,
+            },
+            mounts,
+        )
+        self.assertEqual(mounts[0]["source"], "/raid/models/kimi")
+        for instance in self.plan["role_instances"]:
+            srun = instance["srun_argv"]
+            self.assertIn("--container-writable", srun)
+            self.assertIn("--label", srun)
+            self.assertIn(
+                "--container-image=docker://vllm/vllm-openai:v0.18.1-cu130",
+                srun,
+            )
+            mount_arg = next(arg for arg in srun if arg.startswith("--container-mounts="))
+            self.assertIn("/dev/infiniband:/dev/infiniband", mount_arg)
+            self.assertIn(
+                "/home/inf-kevin/.cache/flashinfer:/root/.cache/flashinfer",
+                mount_arg,
+            )
+
+    def test_salloc_requests_one_exact_topology(self):
+        argv = launcher.build_salloc_argv(
+            self.config, "results/pd.json", script_path="/repo/lib/slurm_pd_launcher.py"
+        )
+        self.assertEqual(argv[0], "salloc")
+        self.assertIn("--nodes=3", argv)
+        self.assertIn("--ntasks=3", argv)
+        self.assertIn("--ntasks-per-node=1", argv)
+        self.assertIn("--gpus-per-node=4", argv)
+        self.assertIn("--partition=batch", argv)
+        self.assertIn("--time=03:00:00", argv)
+        self.assertEqual(argv[-2:], ["--inside-allocation", "supervise"])
+
+    def test_client_runs_in_same_allocation_and_pyxis_image(self):
+        state = {
+            "job_id": "1234",
+            "nodes": self.nodes,
+            "allocation_router_url": "http://slogin-01:31000",
+        }
+        argv = launcher.build_client_srun_argv(
+            self.config,
+            state,
+            [
+                "vllm", "bench", "serve",
+                "--base-url", "{router_url}",
+                "--host", "{router_host}",
+                "--port", "{router_port}",
+                "--model", "{model}",
+            ],
+            self.env,
+        )
+        self.assertIn("--jobid=1234", argv)
+        self.assertIn("--nodelist=c02", argv)
+        self.assertIn("--container-writable", argv)
+        self.assertIn(f"--container-workdir={Path.cwd().resolve()}", argv)
+        mount_arg = next(arg for arg in argv if arg.startswith("--container-mounts="))
+        self.assertIn(
+            f"{Path.cwd().resolve()}:{Path.cwd().resolve()}", mount_arg
+        )
+        self.assertIn("OPENAI_BASE_URL=http://slogin-01:31000", argv)
+        self.assertIn("http://slogin-01:31000", argv)
+        self.assertIn("slogin-01", argv)
+        self.assertIn("31000", argv)
+        self.assertIn("/model", argv)
+
+
+class ValidationAndLifecycleTests(unittest.TestCase):
+    def test_router_raises_nofile_soft_limit_before_start(self):
+        supervisor = object.__new__(launcher.Supervisor)
+        supervisor.plan = {
+            "router": {
+                "argv": ["vllm-router"],
+                "cwd": "/tmp",
+                "env": {},
+                "nofile_limit": 65536,
+                "prefill_urls": ["http://c02:8000"],
+                "decode_urls": ["http://c03:8000", "http://c04:8000"],
+            }
+        }
+        supervisor.children = []
+        supervisor._write_state = mock.Mock()
+        supervisor.popen = mock.Mock(return_value=mock.Mock())
+
+        with mock.patch.object(
+            launcher.resource, "getrlimit", return_value=(1024, 1048576)
+        ), mock.patch.object(launcher.resource, "setrlimit") as setrlimit:
+            supervisor._start_router()
+
+        setrlimit.assert_called_once_with(
+            launcher.resource.RLIMIT_NOFILE, (65536, 1048576)
+        )
+        supervisor.popen.assert_called_once()
+
+    def test_wait_ready_fails_when_supervisor_dies_before_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = str(Path(directory) / "missing.json")
+            with self.assertRaisesRegex(
+                launcher.LaunchError, "exited before creating readiness state"
+            ):
+                launcher.wait_ready(
+                    state_file,
+                    60,
+                    supervisor_pid=1234,
+                    pid_alive=lambda _pid: False,
+                )
+
+    def test_supervise_refuses_ambient_allocation(self):
+        config = serving_config()
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = str(Path(directory) / "state.json")
+            stderr = io.StringIO()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": "/home/tester",
+                    "USER": "tester",
+                    "SLURM_JOB_ID": "9999",
+                },
+                clear=False,
+            ):
+                with contextlib.redirect_stderr(stderr):
+                    status = launcher.main(
+                        [
+                            "--config", json.dumps(config),
+                            "--state-file", state_file,
+                            "supervise",
+                        ]
+                    )
+            self.assertEqual(status, 2)
+            self.assertIn("refusing to adopt", stderr.getvalue())
+            state = json.loads(Path(state_file).read_text())
+            self.assertIn("refusing to adopt", state["error"])
+            self.assertEqual(state["job_id"], "")
+            self.assertFalse(state["owns_allocation"])
+            self.assertEqual(state["grace_period_s"], 0)
+
+    def test_stop_refuses_unowned_allocation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = Path(directory) / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "job_id": "9999",
+                        "owns_allocation": False,
+                        "controller_host": os.uname().nodename,
+                        "children": [],
+                    }
+                )
+            )
+            with self.assertRaisesRegex(
+                launcher.LaunchError, "not owned by this launcher"
+            ):
+                launcher.stop_from_state(str(state_file))
+
+    def test_stop_signals_owned_local_controller_before_scancel(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = Path(directory) / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "job_id": "9999",
+                        "owns_allocation": True,
+                        "controller_host": "login-01",
+                        "controller_pid": 4242,
+                        "grace_period_s": 5,
+                    }
+                )
+            )
+            pid_alive = mock.Mock(side_effect=[True, True, False])
+            send_signal = mock.Mock()
+            run_command = mock.Mock()
+
+            with mock.patch.object(
+                launcher.socket, "gethostname", return_value="login-01"
+            ):
+                launcher.stop_from_state(
+                    str(state_file),
+                    pid_alive=pid_alive,
+                    send_signal=send_signal,
+                    run_command=run_command,
+                    sleep=lambda _seconds: None,
+                )
+
+            send_signal.assert_called_once_with(4242, launcher.signal.SIGTERM)
+            run_command.assert_not_called()
+
+    def test_stop_falls_back_to_scancel_after_controller_grace(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = Path(directory) / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "job_id": "9999",
+                        "owns_allocation": True,
+                        "controller_host": "login-01",
+                        "controller_pid": 4242,
+                        "grace_period_s": 0,
+                    }
+                )
+            )
+            current_time = [0.0]
+
+            def advance(seconds):
+                current_time[0] += seconds
+
+            send_signal = mock.Mock()
+            run_command = mock.Mock(
+                return_value=launcher.subprocess.CompletedProcess(
+                    ["scancel", "9999"], 0
+                )
+            )
+            with mock.patch.object(
+                launcher.socket, "gethostname", return_value="login-01"
+            ):
+                launcher.stop_from_state(
+                    str(state_file),
+                    pid_alive=lambda _pid: True,
+                    send_signal=send_signal,
+                    run_command=run_command,
+                    now=lambda: current_time[0],
+                    sleep=advance,
+                )
+
+            send_signal.assert_called_once_with(4242, launcher.signal.SIGTERM)
+            run_command.assert_called_once_with(["scancel", "9999"], check=False)
+            self.assertEqual(current_time[0], launcher.STOP_EXIT_SLACK_S)
+
+    def test_stop_uses_scancel_for_remote_controller_and_reports_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_file = Path(directory) / "state.json"
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "job_id": "9999",
+                        "owns_allocation": True,
+                        "controller_host": "another-login",
+                        "controller_pid": 4242,
+                        "grace_period_s": 120,
+                    }
+                )
+            )
+            run_command = mock.Mock(
+                return_value=launcher.subprocess.CompletedProcess(
+                    ["scancel", "9999"], 1
+                )
+            )
+
+            with self.assertRaisesRegex(launcher.LaunchError, "scancel failed"):
+                launcher.stop_from_state(
+                    str(state_file),
+                    send_signal=mock.Mock(),
+                    run_command=run_command,
+                )
+
+    def test_stop_wait_is_bounded_even_for_large_configured_grace(self):
+        self.assertEqual(
+            launcher._stop_wait_s({"grace_period_s": 10_000}),
+            launcher.MAX_STOP_WAIT_S,
+        )
+
+    def test_requires_canonical_role_specific_kv_roles(self):
+        config = serving_config()
+        config["roles"][0]["kv_role"] = "kv_both"
+        with self.assertRaisesRegex(launcher.ConfigError, "kv_producer"):
+            launcher.validate_config(config)
+
+    def test_requires_infiniband_and_persistent_flashinfer_mounts(self):
+        for target, message in (
+            ("/dev/infiniband", "NIXL"),
+            ("/root/.cache/flashinfer", "FlashInfer"),
+        ):
+            with self.subTest(target=target):
+                config = serving_config()
+                mounts = config["slurm"]["container"]["mounts"]
+                config["slurm"]["container"]["mounts"] = [
+                    mount for mount in mounts if mount["target"] != target
+                ]
+                with self.assertRaisesRegex(launcher.ConfigError, message):
+                    launcher.validate_config(config)
+
+    def test_controller_only_validates_shared_flashinfer_cache(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache = Path(directory) / "flashinfer"
+            mounts = [
+                {
+                    "source": "/raid/model-only-on-compute-nodes",
+                    "target": "/model",
+                    "read_only": True,
+                },
+                {
+                    "source": "/dev/infiniband-only-on-compute-nodes",
+                    "target": "/dev/infiniband",
+                    "read_only": False,
+                },
+                {
+                    "source": str(cache),
+                    "target": "/root/.cache/flashinfer",
+                    "read_only": False,
+                },
+            ]
+            launcher.ensure_runtime_mounts(mounts)
+            self.assertTrue(cache.is_dir())
+
+    def test_wait_for_checks_fails_as_soon_as_a_child_exits(self):
+        calls = []
+
+        def failed_guard():
+            calls.append("guard")
+            raise launcher.LaunchError("decode[0] exited unexpectedly")
+
+        with self.assertRaisesRegex(launcher.LaunchError, r"decode\[0\]"):
+            launcher.wait_for_checks(
+                [{"url": "http://c08:8000/health", "timeout_s": 10, "poll_interval_s": 1}],
+                process_guard=failed_guard,
+                healthy=lambda _url: False,
+                now=lambda: 0,
+                sleep=lambda _seconds: None,
+            )
+        self.assertEqual(calls, ["guard"])
+
+    def test_supervisor_guard_detects_any_dead_srun_during_runtime(self):
+        alive = mock.Mock(pid=100, poll=mock.Mock(return_value=None))
+        dead = mock.Mock(pid=101, poll=mock.Mock(return_value=9))
+        supervisor = object.__new__(launcher.Supervisor)
+        supervisor.children = [
+            launcher.ChildProcess("prefill[0]", alive),
+            launcher.ChildProcess("decode[0]", dead),
+        ]
+        with self.assertRaisesRegex(launcher.LaunchError, r"decode\[0\].*status 9"):
+            supervisor._guard_children()
+
+    def test_dry_run_needs_no_slurm_and_redacts_secret_env(self):
+        config = serving_config()
+        config["roles"][0]["env"]["HF_TOKEN"] = "very-secret"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config, f)
+            config_path = f.name
+        output = io.StringIO()
+        try:
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": "/home/tester", "USER": "tester"},
+                clear=False,
+            ):
+                with contextlib.redirect_stdout(output):
+                    status = launcher.main(
+                        [
+                            "--config",
+                            config_path,
+                            "--nodes",
+                            ",".join(f"c{i:02d}" for i in range(2, 5)),
+                            "dry-run",
+                        ]
+                    )
+            self.assertEqual(status, 0)
+            self.assertNotIn("very-secret", output.getvalue())
+            plan = json.loads(output.getvalue())
+            self.assertEqual(plan["allocation"]["total_nodes"], 3)
+            self.assertEqual(plan["role_instances"][-1]["nodes"], ["c04"])
+        finally:
+            Path(config_path).unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workloads/kimi_k3_gb300_pd.yaml
+++ b/workloads/kimi_k3_gb300_pd.yaml
@@ -1,0 +1,182 @@
+# Kimi-K3 MXFP4 prefill/decode disaggregation on GB300 Slurm nodes.
+# Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K3
+#
+# This is an opt-in bring-up workload. It uses one DEP4 prefill instance and
+# two independent TEP4 decode replicas:
+#   1 * (1 node * 4 GPUs) prefill + 2 * (1 node * 4 GPUs) decode = 12 GPUs.
+#
+# Topology note: K3 is a 2.8T-param MoE, much larger than K2.5. The recipe
+# recommends at least 8x GB300; this 3-node / 12-GPU layout mirrors the proven
+# K2.5 PD template (the launcher + router are validated for this shape) and is
+# a bring-up topology that may need more nodes for real production traffic.
+name: kimi_k3-gb300-pd
+gpu: GB300
+num_gpus: 12
+nightly: false
+bench_only: true
+timeout_in_minutes: 240
+
+vllm:
+  model: /model
+  # No image: default to the nightly under test like the other workloads (K3
+  # support is in current nightlies). The VLLM_IMAGE / VLLM_COMMIT override
+  # applies as usual.
+  env:
+    # First startup on GB300 can spend tens of minutes autotuning FlashInfer's
+    # kernels. Keep vLLM's internal wait aligned with role health checks.
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_NIXL_SIDE_CHANNEL_PORT: "5600"
+    UCX_MEMTYPE_CACHE: "n"
+    # This is an allow-list; omitting cuda_ipc excludes it without making UCX
+    # try to resolve the literal transport name "^cuda_ipc".
+    UCX_TLS: "rc,cuda_copy"
+    UCX_NET_DEVICES: "mlx5_4:1"
+    # MNNVL (multi-node NVLink) on GB300 NVL, per the K3 recipe notes.
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_DEBUG: WARN
+    NCCL_SOCKET_IFNAME: enP22p3s0f0np0
+    GLOO_SOCKET_IFNAME: enP22p3s0f0np0
+
+serving:
+  version: 1
+  mode: pd_disagg
+  launcher: slurm
+  # The K3 checkpoint's calibrated FP8 KV scales are not yet trusted for MLA
+  # models here. Use BF16 until the loader path is verified so the benchmark
+  # output is numerically trustworthy (same rationale as K2.5 on v0.25.1).
+  # Once verified, FP8 KV cache is available via:
+  #   --kv-cache-dtype fp8
+  #   --attention-config '{"use_prefill_query_quantization":true,"mla_prefill_backend":"flashinfer"}'
+  common_serve_args: >-
+    --enable-expert-parallel
+    --trust-remote-code
+    --block-size 64
+    --kv-cache-dtype bfloat16
+    --gpu-memory-utilization 0.90
+    --max-model-len 9216
+    --no-enable-prefix-caching
+    --attention-backend FLASHINFER_MLA
+    --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED"}'
+    --moe-backend flashinfer_trtllm
+    --all2all-backend allgather_reducescatter
+    --enable-sleep-mode
+    --disable-uvicorn-access-log
+    --safetensors-load-strategy prefetch
+    --language-model-only
+    --enforce-eager
+    --api-server-count 1
+  slurm:
+    partition: batch
+    time_limit: "03:00:00"
+    grace_period_s: 120
+    container:
+      runtime: pyxis
+      mounts:
+        # The Slurm cluster mounts model weights from shared storage; the
+        # exact K3 path may need adjustment by the cluster operator, hence
+        # the source_env override.
+        - source: /raid/shared/nvidia/Kimi-K3
+          source_env: KIMI_K3_MODEL_PATH
+          target: /model
+          read_only: true
+        # NIXL cannot initialize RDMA without the device mount.
+        - source: /dev/infiniband
+          target: /dev/infiniband
+        # Reuse expensive FlashInfer JIT artifacts across allocations.
+        - source: /home/${USER}/.cache/flashinfer
+          source_env: FLASHINFER_CACHE_PATH
+          target: /root/.cache/flashinfer
+  kv_transfer:
+    connector: NixlConnector
+    load_failure_policy: fail
+    extra_config:
+      num_threads: 4
+  roles:
+    - role: prefill
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      # TP1 x DP4 with EP enabled by common_serve_args => DEP4.
+      tensor_parallel_size: 1
+      base_port: 8000
+      kv_role: kv_producer
+      serve_args: >-
+        --max-num-seqs 7
+        --max-num-batched-tokens 24576
+        --no-enable-chunked-prefill
+      health_check:
+        path: /health
+        timeout_s: 3600
+        poll_interval_s: 10
+    - role: decode
+      count: 2
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      # Each replica is TP4 x DP1 with EP enabled => TEP4; count=2 gives x2.
+      tensor_parallel_size: 4
+      base_port: 8000
+      kv_role: kv_consumer
+      serve_args: >-
+        --max-num-seqs 180
+        --stream-interval 50
+      health_check:
+        path: /health
+        timeout_s: 3600
+        poll_interval_s: 10
+  router:
+    repo_path: ${HOME}/Kimi-PD/vllm-router
+    revision: v0.1.12
+    command:
+      - target/release/vllm-router
+    policy: round_robin
+    listen_host: 0.0.0.0
+    client_host: 127.0.0.1
+    port: 31000
+    # The concurrency-3072 benchmark needs several sockets per in-flight
+    # two-stage request; 8192 is the login-node process hard limit.
+    nofile_limit: 8192
+    # v0.1.12 has one global DP expansion setting. Endpoint-level routing lets
+    # vLLM balance the prefill node's local DP4 ranks while each TEP4 decoder
+    # remains one logical router worker.
+    intra_node_data_parallel_size: 1
+    prefill_endpoints: all_instances
+    decode_endpoints: all_nodes
+    health_check:
+      path: /readiness
+      timeout_s: 600
+      poll_interval_s: 5
+
+vllm_bench:
+  metadata:
+    device: gb300
+    precision: mxfp4
+    # Two TP4 decode replicas provide an effective decoder parallel degree of 8;
+    # all 12 serving GPUs participate in end-to-end throughput.
+    tp: 8
+    total_gpus: 12
+    disagg: true
+    is_multinode: true
+  configs:
+    - name: smoke-8k-in-64-out
+      backend: vllm
+      dataset: random
+      input_len: 8192
+      output_len: 64
+      num_prompts: 4
+      max_concurrency: 4
+    - name: 8k-in-1k-out
+      backend: vllm
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 6144
+      max_concurrency: 3072
+    - name: 8k-in-1k-out-long
+      backend: vllm
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 30720
+      max_concurrency: 3072

--- a/workloads/kimi_k3_gb300_pd_dspark.yaml
+++ b/workloads/kimi_k3_gb300_pd_dspark.yaml
@@ -1,0 +1,184 @@
+# Kimi-K3 MXFP4 prefill/decode disaggregation on GB300 Slurm nodes, with the
+# DSpark speculative-decoding draft head (Inferact/Kimi-K3-DSpark).
+# Recipe: https://recipes.vllm.ai/moonshotai/Kimi-K3
+#
+# This is an opt-in bring-up workload. It uses one DEP4 prefill instance and
+# two independent TEP4 decode replicas:
+#   1 * (1 node * 4 GPUs) prefill + 2 * (1 node * 4 GPUs) decode = 12 GPUs.
+#
+# Topology note: K3 is a 2.8T-param MoE, much larger than K2.5. The recipe
+# recommends at least 8x GB300; this 3-node / 12-GPU layout mirrors the proven
+# K2.5 PD template (the launcher + router are validated for this shape) and is
+# a bring-up topology that may need more nodes for real production traffic.
+name: kimi_k3-gb300-pd-dspark
+gpu: GB300
+num_gpus: 12
+nightly: false
+bench_only: true
+timeout_in_minutes: 240
+
+vllm:
+  model: /model
+  # No image: default to the nightly under test like the other workloads (K3
+  # support is in current nightlies). The VLLM_IMAGE / VLLM_COMMIT override
+  # applies as usual.
+  env:
+    # First startup on GB300 can spend tens of minutes autotuning FlashInfer's
+    # kernels. Keep vLLM's internal wait aligned with role health checks.
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_NIXL_SIDE_CHANNEL_PORT: "5600"
+    UCX_MEMTYPE_CACHE: "n"
+    # This is an allow-list; omitting cuda_ipc excludes it without making UCX
+    # try to resolve the literal transport name "^cuda_ipc".
+    UCX_TLS: "rc,cuda_copy"
+    UCX_NET_DEVICES: "mlx5_4:1"
+    # MNNVL (multi-node NVLink) on GB300 NVL, per the K3 recipe notes.
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_DEBUG: WARN
+    NCCL_SOCKET_IFNAME: enP22p3s0f0np0
+    GLOO_SOCKET_IFNAME: enP22p3s0f0np0
+
+serving:
+  version: 1
+  mode: pd_disagg
+  launcher: slurm
+  # The K3 checkpoint's calibrated FP8 KV scales are not yet trusted for MLA
+  # models here. Use BF16 until the loader path is verified so the benchmark
+  # output is numerically trustworthy (same rationale as K2.5 on v0.25.1).
+  # Once verified, FP8 KV cache is available via:
+  #   --kv-cache-dtype fp8
+  #   --attention-config '{"use_prefill_query_quantization":true,"mla_prefill_backend":"flashinfer"}'
+  common_serve_args: >-
+    --enable-expert-parallel
+    --trust-remote-code
+    --block-size 64
+    --kv-cache-dtype bfloat16
+    --gpu-memory-utilization 0.90
+    --max-model-len 9216
+    --no-enable-prefix-caching
+    --attention-backend FLASHINFER_MLA
+    --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED"}'
+    --moe-backend flashinfer_trtllm
+    --all2all-backend allgather_reducescatter
+    --enable-sleep-mode
+    --disable-uvicorn-access-log
+    --safetensors-load-strategy prefetch
+    --language-model-only
+    --enforce-eager
+    --api-server-count 1
+    --speculative-config '{"model":"Inferact/Kimi-K3-DSpark","method":"dspark","num_speculative_tokens":7,"attention_backend":"FLASHINFER_MLA","draft_sample_method":"probabilistic","rejection_sample_method":"block"}'
+  slurm:
+    partition: batch
+    time_limit: "03:00:00"
+    grace_period_s: 120
+    container:
+      runtime: pyxis
+      mounts:
+        # The Slurm cluster mounts model weights from shared storage; the
+        # exact K3 path may need adjustment by the cluster operator, hence
+        # the source_env override.
+        - source: /raid/shared/nvidia/Kimi-K3
+          source_env: KIMI_K3_MODEL_PATH
+          target: /model
+          read_only: true
+        # NIXL cannot initialize RDMA without the device mount.
+        - source: /dev/infiniband
+          target: /dev/infiniband
+        # Reuse expensive FlashInfer JIT artifacts across allocations.
+        - source: /home/${USER}/.cache/flashinfer
+          source_env: FLASHINFER_CACHE_PATH
+          target: /root/.cache/flashinfer
+  kv_transfer:
+    connector: NixlConnector
+    load_failure_policy: fail
+    extra_config:
+      num_threads: 4
+  roles:
+    - role: prefill
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      # TP1 x DP4 with EP enabled by common_serve_args => DEP4.
+      tensor_parallel_size: 1
+      base_port: 8000
+      kv_role: kv_producer
+      serve_args: >-
+        --max-num-seqs 7
+        --max-num-batched-tokens 24576
+        --no-enable-chunked-prefill
+      health_check:
+        path: /health
+        timeout_s: 3600
+        poll_interval_s: 10
+    - role: decode
+      count: 2
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      # Each replica is TP4 x DP1 with EP enabled => TEP4; count=2 gives x2.
+      tensor_parallel_size: 4
+      base_port: 8000
+      kv_role: kv_consumer
+      serve_args: >-
+        --max-num-seqs 180
+        --stream-interval 50
+      health_check:
+        path: /health
+        timeout_s: 3600
+        poll_interval_s: 10
+  router:
+    repo_path: ${HOME}/Kimi-PD/vllm-router
+    revision: v0.1.12
+    command:
+      - target/release/vllm-router
+    policy: round_robin
+    listen_host: 0.0.0.0
+    client_host: 127.0.0.1
+    port: 31000
+    # The concurrency-3072 benchmark needs several sockets per in-flight
+    # two-stage request; 8192 is the login-node process hard limit.
+    nofile_limit: 8192
+    # v0.1.12 has one global DP expansion setting. Endpoint-level routing lets
+    # vLLM balance the prefill node's local DP4 ranks while each TEP4 decoder
+    # remains one logical router worker.
+    intra_node_data_parallel_size: 1
+    prefill_endpoints: all_instances
+    decode_endpoints: all_nodes
+    health_check:
+      path: /readiness
+      timeout_s: 600
+      poll_interval_s: 5
+
+vllm_bench:
+  metadata:
+    device: gb300
+    precision: mxfp4
+    # Two TP4 decode replicas provide an effective decoder parallel degree of 8;
+    # all 12 serving GPUs participate in end-to-end throughput.
+    tp: 8
+    total_gpus: 12
+    disagg: true
+    is_multinode: true
+  configs:
+    - name: smoke-8k-in-64-out
+      backend: vllm
+      dataset: random
+      input_len: 8192
+      output_len: 64
+      num_prompts: 4
+      max_concurrency: 4
+    - name: 8k-in-1k-out
+      backend: vllm
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 6144
+      max_concurrency: 3072
+    - name: 8k-in-1k-out-long
+      backend: vllm
+      dataset: random
+      input_len: 8192
+      output_len: 1024
+      num_prompts: 30720
+      max_concurrency: 3072


### PR DESCRIPTION
This PR was authored with assistance from Kimi Code CLI.

## Summary

Adds GB300 Slurm prefill/decode-disaggregation (PD) infrastructure and two Kimi
K3 PD workloads. This is a self-contained rebuild of the closed #36 (K2.5 PD)
rebased onto current `main`, with the K2.5 workload dropped and the K3 workloads
from #71 carried in — K2.5 is superseded by K3.

**Infrastructure** (from #36, rebased onto main and reconciled with the
benchmark-repetitions / concurrency-sweep / `timeout_in_minutes` features that
landed since):

- `serving:` schema v1 in `lib/parse_workload.py` (Slurm PD validation →
  launcher-ready `SERVING_JSON`).
- `lib/slurm_pd_launcher.py` — Slurm/Pyxis allocation, role-aware process
  placement, NIXL KV-transfer config, router lifecycle.
- `GB300` profile (`gb300-slurm` queue, `server_runtime: slurm`) and Slurm step
  handling in `.buildkite/generate_pipeline.py` (queue-scoped `concurrency: 1` /
  `eager` mutual exclusion).
- `run.sh` / `run_vllm_bench.sh` / `ingest_perf.py` PD support, README docs,
  tests, and a PD model-onboarding agent skill.

**Workloads** (opt-in, `nightly: false`, `bench_only: true`):

- `workloads/kimi_k3_gb300_pd.yaml` — regular K3 PD.
- `workloads/kimi_k3_gb300_pd_dspark.yaml` — adds the DSpark speculative-decoding
  draft head (`Inferact/Kimi-K3-DSpark`, `method: dspark`, 7 speculative tokens).

Both use 3 GB300 nodes (1 DEP4 prefill + 2 TEP4 decode = 12 GPUs), default to the
nightly image (no `image:`/`pin_image:` — K3 is in current nightlies), MXFP4
precision, BF16 KV cache, and the MNNVL/NCCL env for GB300 NVL.

## Validation

- `python3 -m unittest discover -s tests` — 36/36.
- `.buildkite/test_generate_pipeline.py` — 7/7; `.buildkite/test_benchmark_repetitions.py` — 7/7.
- Parser smoke on both K3 workloads: `SERVING_MODE=pd_disagg`, `total_gpus: 12`,
  bench names single-suffixed (`smoke-8k-in-64-out-conc-4`, `8k-in-1k-out-conc-3072`,
  `8k-in-1k-out-long-conc-3072`).
- `bash -n` on all shell libs; `py_compile` on the Python files; `git diff --check`.
- Pipeline generation routes both to `gb300-slurm` with `concurrency: 1`/`eager`;
  the default nightly set excludes them (opt-in).

## Notes

- The K3 PD workloads have **not** run on hardware yet — they need the GB300
  Slurm cluster. Static validation only.
- The 3-node / 12-GPU topology mirrors the validated K2.5 PD template; K3 is a
  2.8T model, so this is a bring-up topology that may need more nodes for
  production traffic.
- The K3 recipe notes the `kimi-k3` image is cu130-only; these workloads default
  to `vllm/vllm-openai:nightly`, so a cu129 nightly would fail to serve K3 — that
  would surface as a startup error.

Supersedes #36 (closed) and #71.
