### PR TITLE
Fix image-resolution tests

### DIFF
--- a/.buildkite/test_generate_pipeline.py
+++ b/.buildkite/test_generate_pipeline.py
@@ -287,24 +287,11 @@ def test_ecr_pull_through_remains_default():
 
 
 def test_cuda_release_image_does_not_select_rocm_commit():
-    image_key = "VLLM_IMAGE"
-    commit_key = "VLLM_COMMIT"
-    previous_image = os.environ.get(image_key)
-    previous_commit = os.environ.get(commit_key)
-    os.environ[image_key] = "public.ecr.aws/example/release:abc123def456-x86_64"
-    os.environ.pop(commit_key, None)
-    try:
-        image = g.resolved_image({}, {"image_repo": "vllm/vllm-openai-rocm"})
-    finally:
-        if previous_image is None:
-            os.environ.pop(image_key, None)
-        else:
-            os.environ[image_key] = previous_image
-        if previous_commit is None:
-            os.environ.pop(commit_key, None)
-        else:
-            os.environ[commit_key] = previous_commit
-    assert image == "vllm/vllm-openai-rocm:nightly"
+    """A CUDA release image embeds a commit, but AMD has no build of it: fall
+    back to the ROCm nightly rather than a same-commit image that never existed.
+    """
+    with build_env(VLLM_IMAGE="public.ecr.aws/example/release:abc123def456-x86_64"):
+        assert g.resolved_image({}, ROCM) == "vllm/vllm-openai-rocm:nightly"
 
 
 def main():

--- a/.buildkite/test_parse_workload.py
+++ b/.buildkite/test_parse_workload.py
@@ -12,6 +12,15 @@ assert SPEC and SPEC.loader
 parse_workload = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(parse_workload)
 
+IMAGE_VARS = ("VLLM_IMAGE", "VLLM_IMAGE_CUDA", "VLLM_IMAGE_ROCM", "VLLM_COMMIT")
+
+
+@pytest.fixture(autouse=True)
+def build_env(monkeypatch):
+    """Resolve images from what the test sets, not what the build's env pins."""
+    for var in IMAGE_VARS:
+        monkeypatch.delenv(var, raising=False)
+
 
 def write_workload(tmp_path: Path, startup_timeout_s: object) -> Path:
     (tmp_path / "lib").mkdir()
@@ -57,10 +66,12 @@ def test_rejects_invalid_server_startup_timeout(tmp_path, value):
 
 
 def test_cuda_release_image_does_not_select_rocm_commit(monkeypatch):
+    """A CUDA release image embeds a commit, but AMD has no build of it: fall
+    back to the ROCm nightly rather than a same-commit image that never existed.
+    """
     monkeypatch.setenv(
         "VLLM_IMAGE", "public.ecr.aws/example/release:abc123def456-x86_64"
     )
-    monkeypatch.delenv("VLLM_COMMIT", raising=False)
 
     image, commit = parse_workload.resolve_image(
         {}, {"image_repo": "vllm/vllm-openai-rocm"}


### PR DESCRIPTION
test_cuda_release_image_does_not_select_rocm_commit saved and restored only VLLM_IMAGE and VLLM_COMMIT, so the VLLM_IMAGE_CUDA / VLLM_IMAGE_ROCM pins added in #63 leaked in from the build environment. In a build that pins a ROCm image the pin correctly outranks the workload default, and the test failed on an expectation that only holds when no pin is set.

Use the existing build_env helper in the generator test, and clear all four vars in an autouse fixture for the parse_workload tests.