### PR TITLE
Set OMP_NUM_THREADS=1 globally on ROCm

### DIFF
--- a/lib/gpu_profiles.yaml
+++ b/lib/gpu_profiles.yaml
@@ -21,6 +21,9 @@ MI300X:
   ecr_pull_through_cache: false
   server_runtime: native
   k8s_plugin: amd
+  env:
+    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
+    OMP_NUM_THREADS: 1
   # HF cache lives in the container default and is backed by an emptyDir volume
   # (reclaimed when the pod exits). A cluster with fast shared storage can point
   # this at a PVC/hostPath via the MI300X_HF_CACHE_VOLUME override; do NOT set an
@@ -33,5 +36,8 @@ MI355X:
   ecr_pull_through_cache: false
   server_runtime: native
   k8s_plugin: amd
+  env:
+    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
+    OMP_NUM_THREADS: 1
   # See MI300X — HF cache defaults to an emptyDir-backed container path; override
   # the volume source per-cluster with MI355X_HF_CACHE_VOLUME.

--- a/workloads/deepseek_v4_pro_mi355x.yaml
+++ b/workloads/deepseek_v4_pro_mi355x.yaml
@@ -8,8 +8,6 @@ vllm:
   model: deepseek-ai/DeepSeek-V4-Pro
   env:
     VLLM_ROCM_USE_AITER: 1
-    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
-    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --kv-cache-dtype fp8

--- a/workloads/glm_5_2_mi355x.yaml
+++ b/workloads/glm_5_2_mi355x.yaml
@@ -8,8 +8,6 @@ vllm:
   model: zai-org/GLM-5.2-FP8
   env:
     VLLM_ROCM_USE_AITER: 1
-    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
-    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code

--- a/workloads/kimi_k2_5_mi300x.yaml
+++ b/workloads/kimi_k2_5_mi300x.yaml
@@ -10,8 +10,6 @@ vllm:
   env:
     VLLM_ROCM_USE_AITER: 1
     VLLM_ENGINE_READY_TIMEOUT_S: 7200
-    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
-    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code

--- a/workloads/kimi_k2_5_mi355x.yaml
+++ b/workloads/kimi_k2_5_mi355x.yaml
@@ -8,8 +8,6 @@ vllm:
   model: moonshotai/Kimi-K2.5
   env:
     VLLM_ROCM_USE_AITER: 1
-    # OMP_NUM_THREADS=1 workaround after weight loading regression from https://github.com/vllm-project/vllm/pull/49919
-    OMP_NUM_THREADS: 1
   serve_args: >-
     --tensor-parallel-size 8
     --trust-remote-code


### PR DESCRIPTION
Speed up model weight loading across all workloads.