### PR TITLE
Use raw completions for GPT-OSS B200 perf

### DIFF
--- a/.buildkite/test_benchmark_repetitions.py
+++ b/.buildkite/test_benchmark_repetitions.py
@@ -161,6 +161,21 @@ def test_long_h200_workloads_have_expected_timeouts():
         assert workload.get("timeout_in_minutes") == timeout, path
 
 
+def test_gpt_oss_b200_fixed_length_benchmark_uses_raw_completions():
+    import yaml
+
+    path = os.path.join(ROOT, "workloads", "gpt_oss_120b_b200.yaml")
+    with open(path) as f:
+        workload = yaml.safe_load(f)
+
+    configs = (workload.get("vllm_bench") or {}).get("configs") or []
+    fixed_length = [
+        config for config in configs if config.get("name") == "8k-in-1k-out"
+    ]
+    assert len(fixed_length) == 1, path
+    assert fixed_length[0].get("backend") == "openai", path
+
+
 def main():
     tests = [value for key, value in sorted(globals().items()) if key.startswith("test_")]
     failed = 0

--- a/workloads/gpt_oss_120b_b200.yaml
+++ b/workloads/gpt_oss_120b_b200.yaml
@@ -44,7 +44,10 @@ bfcl:
 vllm_bench:
   configs:
     - name: 8k-in-1k-out
-      backend: openai-chat
+      # Use raw completions for this fixed-length synthetic benchmark. The
+      # GPT-OSS chat/Harmony path can stop before output_len, which makes its
+      # throughput and TPOT results incomparable with true 8k-in/1k-out runs.
+      backend: openai
       dataset: random
       input_len: 8192
       output_len: 1024


### PR DESCRIPTION
## Summary

- use the raw OpenAI completions backend for the GPT-OSS 120B B200 fixed-length serving benchmark
- document why chat/Harmony early stopping makes those results incomparable
- add a regression test that pins the benchmark to the raw completions backend

## Why

The chat-backed runs produced about 63 output tokens per request even though the workload declared 1,024, while the raw completions run produced exactly 1,024. The dashboard then compared the two as the same 8k-in/1k-out workload, creating a false 89% output-throughput regression.

## Tests

- `python3 .buildkite/test_benchmark_repetitions.py` (8/8)
- `python3 .buildkite/test_generate_pipeline.py` (21/21)
